### PR TITLE
Documentation cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/scalacheck/native/target modules/framework-cats/native/target modules/framework/jvm/target modules/docs/jvm/target modules/core/native/target modules/framework/native/target modules/core/js/target modules/framework/js/target modules/core/jvm/target modules/core-cats/native/target modules/discipline/native/target modules/core-cats/js/target modules/framework-cats/js/target modules/framework-cats/jvm/target modules/discipline/js/target modules/scalacheck/jvm/target modules/discipline/jvm/target modules/core-cats/jvm/target modules/scalacheck/js/target project/target
+        run: mkdir -p modules/scalacheck/native/target modules/framework-cats/native/target modules/framework/jvm/target modules/core/native/target modules/framework/native/target modules/core/js/target modules/framework/js/target modules/core/jvm/target modules/core-cats/native/target modules/discipline/native/target modules/core-cats/js/target modules/framework-cats/js/target modules/framework-cats/jvm/target modules/discipline/js/target modules/scalacheck/jvm/target modules/discipline/jvm/target modules/core-cats/jvm/target modules/scalacheck/js/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/scalacheck/native/target modules/framework-cats/native/target modules/framework/jvm/target modules/docs/jvm/target modules/core/native/target modules/framework/native/target modules/core/js/target modules/framework/js/target modules/core/jvm/target modules/core-cats/native/target modules/discipline/native/target modules/core-cats/js/target modules/framework-cats/js/target modules/framework-cats/jvm/target modules/discipline/js/target modules/scalacheck/jvm/target modules/discipline/jvm/target modules/core-cats/jvm/target modules/scalacheck/js/target project/target
+        run: tar cf targets.tar modules/scalacheck/native/target modules/framework-cats/native/target modules/framework/jvm/target modules/core/native/target modules/framework/native/target modules/core/js/target modules/framework/js/target modules/core/jvm/target modules/core-cats/native/target modules/discipline/native/target modules/core-cats/js/target modules/framework-cats/js/target modules/framework-cats/jvm/target modules/discipline/js/target modules/scalacheck/jvm/target modules/discipline/jvm/target modules/core-cats/jvm/target modules/scalacheck/js/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -265,7 +265,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: rootjs_2.12 rootjs_2.13 rootjs_3 weaver-docs_2.12 weaver-docs_2.13 weaver-docs_3 rootjvm_2.12 rootjvm_2.13 rootjvm_3 rootnative_2.12 rootnative_2.13 rootnative_3
+          modules-ignore: rootjs_2.12 rootjs_2.13 rootjs_3 docs-output_2.12 docs-output_2.13 docs-output_3 weaver-docs_2.12 weaver-docs_2.13 weaver-docs_3 rootjvm_2.12 rootjvm_2.13 rootjvm_3 rootnative_2.12 rootnative_2.13 rootnative_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ val Version = new {
   val testInterface          = "1.0"
   val scalacCompatAnnotation = "0.1.4"
   val http4s                 = "0.23.26"
-  val http4sBlaze            = "0.23.16"
 }
 
 lazy val root = tlCrossRootProject.aggregate(core,
@@ -169,17 +168,14 @@ lazy val discipline = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 
 lazy val docsOutput = crossProject(JVMPlatform)
   .in(file("modules/docs"))
+  .enablePlugins(NoPublishPlugin)
   .dependsOn(core, framework, coreCats, cats, scalacheck, discipline)
   .settings(
-    moduleName := "docs",
+    moduleName := "docs-output",
     name       := "output for documentation",
     watchSources += (ThisBuild / baseDirectory).value / "docs",
     libraryDependencies ++= Seq(
-      "org.http4s"    %% "http4s-dsl"          % Version.http4s,
-      "org.http4s"    %% "http4s-blaze-server" % Version.http4sBlaze,
-      "org.http4s"    %% "http4s-blaze-client" % Version.http4sBlaze,
-      "com.lihaoyi"   %% "fansi"               % "0.2.7",
-      "org.typelevel" %% "cats-kernel-laws"    % Version.catsLaws
+      "com.lihaoyi" %% "fansi" % "0.4.0"
     )
   )
 
@@ -199,9 +195,7 @@ lazy val docs = project
     name       := "Weaver documentation",
     watchSources += (ThisBuild / baseDirectory).value / "docs",
     libraryDependencies ++= Seq(
-      "org.http4s"    %% "http4s-dsl"          % Version.http4s,
-      "org.http4s"    %% "http4s-blaze-server" % Version.http4sBlaze,
-      "org.http4s"    %% "http4s-blaze-client" % Version.http4sBlaze,
+      "org.http4s"    %% "http4s-ember-client" % Version.http4s,
       "org.typelevel" %% "cats-laws"           % Version.catsLaws
     ),
     tlSiteHelium ~= (_.site.internalCSS(Root / "assets")

--- a/docs/features/resources.md
+++ b/docs/features/resources.md
@@ -11,7 +11,7 @@ import weaver._
 import cats.effect._
 
 // Using http4s
-import org.http4s.blaze.client._
+import org.http4s.ember.client._
 import org.http4s.client._
 
 object HttpSuite extends IOSuite {
@@ -19,7 +19,7 @@ object HttpSuite extends IOSuite {
   // Sharing a single http client across all tests
   override type Res = Client[IO]
   override def sharedResource : Resource[IO, Res] =
-    BlazeClientBuilder[IO].resource
+    EmberClientBuilder.default[IO].build
 
   // The test receives the shared client as an argument
   test("Good requests lead to good results") { httpClient =>


### PR DESCRIPTION
- Switch resource example to use Ember over Blaze
- Update version of `fansi`
- Removes un-needed deps in documentation projects
- Adds `NoPublishPlugin` to `docsOutput` project