### PR TITLE
Use initial Seed in CheckConfig and failure message.

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
@@ -1,18 +1,106 @@
 package weaver
 package scalacheck
 
-case class CheckConfig(
-    minimumSuccessful: Int,
-    maximumDiscardRatio: Int,
-    maximumGeneratorSize: Int,
-    perPropertyParallelism: Int,
-    initialSeed: Option[Long]
-) {
+import org.scalacheck.rng.Seed
+
+final class CheckConfig(
+    val minimumSuccessful: Int,
+    val maximumDiscardRatio: Int,
+    val maximumGeneratorSize: Int,
+    val perPropertyParallelism: Int,
+    val initialSeed: Option[Seed]) extends Product with Serializable {
   assert(maximumDiscardRatio >= 0)
   assert(maximumDiscardRatio <= 100)
   assert(minimumSuccessful > 0)
 
   def maximumDiscarded = minimumSuccessful * maximumDiscardRatio / 100
+
+  def withMinimumSuccessful(minimumSuccessful: Int) = new CheckConfig(
+    minimumSuccessful = minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withMaximumDiscardRatio(maximumDiscardRatio: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withMaximumGeneratorSize(maximumGeneratorSize: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withPerPropertyParallelism(perPropertyParallelism: Int) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = perPropertyParallelism,
+    initialSeed = this.initialSeed
+  )
+
+  def withInitialSeed(initialSeed: Option[Seed]) = new CheckConfig(
+    minimumSuccessful = this.minimumSuccessful,
+    maximumDiscardRatio = this.maximumDiscardRatio,
+    maximumGeneratorSize = this.maximumGeneratorSize,
+    perPropertyParallelism = this.perPropertyParallelism,
+    initialSeed = initialSeed
+  )
+
+  override def toString: String = {
+    val b = new StringBuilder("CheckConfig(")
+    b.append(String.valueOf(this.minimumSuccessful))
+    b.append(", ")
+    b.append(String.valueOf(this.maximumDiscardRatio))
+    b.append(", ")
+    b.append(String.valueOf(this.maximumGeneratorSize))
+    b.append(", ")
+    b.append(String.valueOf(this.perPropertyParallelism))
+    b.append(", ")
+    b.append(String.valueOf(this.initialSeed))
+    b.append(")")
+    b.toString()
+  }
+
+  override def canEqual(obj: Any): Boolean =
+    obj != null && obj.isInstanceOf[CheckConfig]
+
+  override def equals(obj: Any): Boolean = canEqual(obj) && {
+    val other = obj.asInstanceOf[CheckConfig]
+    this.minimumSuccessful == other.minimumSuccessful && this.maximumDiscardRatio == other.maximumDiscardRatio && this.maximumGeneratorSize == other.maximumGeneratorSize &&
+    this.perPropertyParallelism == other.perPropertyParallelism && this.initialSeed == other.initialSeed
+  }
+
+  override def hashCode: Int = {
+    var code = 17 + "CheckConfig".##
+    code = 37 * code + this.minimumSuccessful.##
+    code = 37 * code + this.maximumDiscardRatio.##
+    code = 37 * code + this.maximumGeneratorSize.##
+    code = 37 * code + this.perPropertyParallelism.##
+    code = 37 * code + this.initialSeed.##
+    37 * code
+  }
+
+  override def productPrefix: String = "CheckConfig"
+
+  override def productArity: Int = 5
+
+  override def productElement(n: Int): Any = n match {
+    case 0 => this.minimumSuccessful
+    case 1 => this.maximumDiscardRatio
+    case 2 => this.maximumGeneratorSize
+    case 3 => this.perPropertyParallelism
+    case 4 => this.initialSeed
+    case n => throw new IndexOutOfBoundsException(n.toString)
+  }
 }
 
 object CheckConfig {
@@ -23,4 +111,16 @@ object CheckConfig {
     perPropertyParallelism = 10,
     initialSeed = None
   )
+
+  def apply(
+      minimumSuccessful: Int,
+      maximumDiscardRatio: Int,
+      maximumGeneratorSize: Int,
+      perPropertyParallelism: Int,
+      initialSeed: Option[Seed]): CheckConfig =
+    new CheckConfig(minimumSuccessful,
+                    maximumDiscardRatio,
+                    maximumGeneratorSize,
+                    perPropertyParallelism,
+                    initialSeed)
 }

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
@@ -3,104 +3,37 @@ package scalacheck
 
 import org.scalacheck.rng.Seed
 
-final class CheckConfig(
+case class CheckConfig private (
     val minimumSuccessful: Int,
     val maximumDiscardRatio: Int,
     val maximumGeneratorSize: Int,
     val perPropertyParallelism: Int,
-    val initialSeed: Option[Seed]) extends Product with Serializable {
+    val initialSeed: Option[Seed]) {
   assert(maximumDiscardRatio >= 0)
   assert(maximumDiscardRatio <= 100)
   assert(minimumSuccessful > 0)
 
   def maximumDiscarded = minimumSuccessful * maximumDiscardRatio / 100
 
-  def withMinimumSuccessful(minimumSuccessful: Int) = new CheckConfig(
-    minimumSuccessful = minimumSuccessful,
-    maximumDiscardRatio = this.maximumDiscardRatio,
-    maximumGeneratorSize = this.maximumGeneratorSize,
-    perPropertyParallelism = this.perPropertyParallelism,
-    initialSeed = this.initialSeed
+  def withMinimumSuccessful(minimumSuccessful: Int) = copy(
+    minimumSuccessful = minimumSuccessful
   )
 
-  def withMaximumDiscardRatio(maximumDiscardRatio: Int) = new CheckConfig(
-    minimumSuccessful = this.minimumSuccessful,
-    maximumDiscardRatio = maximumDiscardRatio,
-    maximumGeneratorSize = this.maximumGeneratorSize,
-    perPropertyParallelism = this.perPropertyParallelism,
-    initialSeed = this.initialSeed
+  def withMaximumDiscardRatio(maximumDiscardRatio: Int) = copy(
+    maximumDiscardRatio = maximumDiscardRatio
   )
 
-  def withMaximumGeneratorSize(maximumGeneratorSize: Int) = new CheckConfig(
-    minimumSuccessful = this.minimumSuccessful,
-    maximumDiscardRatio = this.maximumDiscardRatio,
-    maximumGeneratorSize = maximumGeneratorSize,
-    perPropertyParallelism = this.perPropertyParallelism,
-    initialSeed = this.initialSeed
+  def withMaximumGeneratorSize(maximumGeneratorSize: Int) = copy(
+    maximumGeneratorSize = maximumGeneratorSize
   )
 
-  def withPerPropertyParallelism(perPropertyParallelism: Int) = new CheckConfig(
-    minimumSuccessful = this.minimumSuccessful,
-    maximumDiscardRatio = this.maximumDiscardRatio,
-    maximumGeneratorSize = this.maximumGeneratorSize,
-    perPropertyParallelism = perPropertyParallelism,
-    initialSeed = this.initialSeed
+  def withPerPropertyParallelism(perPropertyParallelism: Int) = copy(
+    perPropertyParallelism = perPropertyParallelism
   )
 
-  def withInitialSeed(initialSeed: Option[Seed]) = new CheckConfig(
-    minimumSuccessful = this.minimumSuccessful,
-    maximumDiscardRatio = this.maximumDiscardRatio,
-    maximumGeneratorSize = this.maximumGeneratorSize,
-    perPropertyParallelism = this.perPropertyParallelism,
+  def withInitialSeed(initialSeed: Option[Seed]) = copy(
     initialSeed = initialSeed
   )
-
-  override def toString: String = {
-    val b = new StringBuilder("CheckConfig(")
-    b.append(String.valueOf(this.minimumSuccessful))
-    b.append(", ")
-    b.append(String.valueOf(this.maximumDiscardRatio))
-    b.append(", ")
-    b.append(String.valueOf(this.maximumGeneratorSize))
-    b.append(", ")
-    b.append(String.valueOf(this.perPropertyParallelism))
-    b.append(", ")
-    b.append(String.valueOf(this.initialSeed))
-    b.append(")")
-    b.toString()
-  }
-
-  override def canEqual(obj: Any): Boolean =
-    obj != null && obj.isInstanceOf[CheckConfig]
-
-  override def equals(obj: Any): Boolean = canEqual(obj) && {
-    val other = obj.asInstanceOf[CheckConfig]
-    this.minimumSuccessful == other.minimumSuccessful && this.maximumDiscardRatio == other.maximumDiscardRatio && this.maximumGeneratorSize == other.maximumGeneratorSize &&
-    this.perPropertyParallelism == other.perPropertyParallelism && this.initialSeed == other.initialSeed
-  }
-
-  override def hashCode: Int = {
-    var code = 17 + "CheckConfig".##
-    code = 37 * code + this.minimumSuccessful.##
-    code = 37 * code + this.maximumDiscardRatio.##
-    code = 37 * code + this.maximumGeneratorSize.##
-    code = 37 * code + this.perPropertyParallelism.##
-    code = 37 * code + this.initialSeed.##
-    37 * code
-  }
-
-  override def productPrefix: String = "CheckConfig"
-
-  override def productArity: Int = 5
-
-  override def productElement(n: Int): Any = n match {
-    case 0 => this.minimumSuccessful
-    case 1 => this.maximumDiscardRatio
-    case 2 => this.maximumGeneratorSize
-    case 3 => this.perPropertyParallelism
-    case 4 => this.initialSeed
-    case n => throw new IndexOutOfBoundsException(n.toString)
-  }
 }
 
 object CheckConfig {

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/CheckConfig.scala
@@ -2,6 +2,7 @@ package weaver
 package scalacheck
 
 import org.scalacheck.rng.Seed
+import org.typelevel.scalaccompat.annotation.unused
 
 case class CheckConfig private (
     val minimumSuccessful: Int,
@@ -56,4 +57,7 @@ object CheckConfig {
                     maximumGeneratorSize,
                     perPropertyParallelism,
                     initialSeed)
+
+  @unused
+  private def unapply(c: CheckConfig): Some[CheckConfig] = Some(c)
 }

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -136,7 +136,7 @@ trait Checkers {
       val initial = startSeed(
         Gen.Parameters.default
           .withSize(config.maximumGeneratorSize)
-          .withInitialSeed(config.initialSeed.map(Seed(_))))
+          .withInitialSeed(config.initialSeed))
 
       fs2.Stream.iterate(initial) {
         case (p, s) => (p, s.slide)

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -165,7 +165,10 @@ trait Checkers {
         val ith = succeeded + discarded + 1
         val failure = Expectations.Helpers
           .failure(
-            s"Property test failed on try $ith with seed ${seed} and input $input")
+            s"""Property test failed on try $ith with seed $seed and input $input.
+                |You can reproduce this by adding the following override to your suite:
+                |
+                |override def checkConfig = super.checkConfig.withInitialSeed($seed.toOption)""".stripMargin)
           .and(exp)
         copy(failure = Some(failure))
       } else this

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -119,13 +119,8 @@ trait Checkers {
         }
         .takeWhile(_.shouldContinue(config), takeFailure = true)
         .compile
-        .last
-        .map { (x: Option[Status[A]]) =>
-          x match {
-            case Some(status) => status.endResult(config)
-            case None         => Expectations.Helpers.success
-          }
-        }
+        .lastOrError // This will never fail as there will always be at least one status
+        .map { status => status.endResult(config) }
     }
 
     private def startParams: (Gen.Parameters, Seed) = {

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/CheckersConcurrencyTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/CheckersConcurrencyTest.scala
@@ -19,9 +19,10 @@ object CheckersConcurrencyTest extends SimpleIOSuite {
     object CheckersConcurrencyTestNested extends SimpleIOSuite with Checkers {
 
       override def checkConfig: CheckConfig =
-        super.checkConfig.copy(perPropertyParallelism = minTests * 5,
-                               minimumSuccessful = minTests,
-                               maximumDiscardRatio = 10)
+        super.checkConfig
+          .withPerPropertyParallelism(minTests * 5)
+          .withMinimumSuccessful(minTests)
+          .withMaximumDiscardRatio(10)
 
       loggedTest("nested") { log =>
         val atomicInt = new AtomicInteger(0)
@@ -57,9 +58,9 @@ object CheckersConcurrencyTest extends SimpleIOSuite {
     object CheckersConcurrencyTestNested extends SimpleIOSuite with Checkers {
 
       override def checkConfig: CheckConfig =
-        super.checkConfig.copy(perPropertyParallelism = 50,
-                               minimumSuccessful = 10,
-                               maximumDiscardRatio = 10)
+        super.checkConfig.withPerPropertyParallelism(50)
+          .withMinimumSuccessful(10)
+          .withMaximumDiscardRatio(10)
 
       test("nested") {
         val atomicInt = new AtomicInteger(0)

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/CheckersTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/CheckersTest.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen
 object CheckersTest extends SimpleIOSuite with Checkers {
 
   override def checkConfig: CheckConfig =
-    super.checkConfig.copy(perPropertyParallelism = 100)
+    super.checkConfig.withPerPropertyParallelism(100)
 
   test("universal") {
     forall(Gen.posNum[Int]) { a =>

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -8,6 +8,7 @@ import cats.effect.{ IO, Resource }
 import weaver.framework._
 
 import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
 
 object PropertyDogFoodTest extends IOSuite {
 
@@ -102,13 +103,16 @@ object Meta {
 
     override def checkConfig: CheckConfig =
       super.checkConfig
-        .copy(perPropertyParallelism = 100, minimumSuccessful = 100)
+        .withPerPropertyParallelism(100)
+        .withMinimumSuccessful(100)
   }
 
   object FailedChecks extends SimpleIOSuite with Checkers {
 
     override def checkConfig: CheckConfig =
-      super.checkConfig.copy(perPropertyParallelism = 1, initialSeed = Some(5L))
+      super.checkConfig
+        .withPerPropertyParallelism(1)
+        .withInitialSeed(Some(Seed(5L)))
 
     test("foobar") {
       forall { (x: Int) =>
@@ -127,8 +131,9 @@ object Meta {
   object ConfigOverrideChecks extends DiscardedChecks {
 
     val configOverride =
-      super.checkConfig.copy(minimumSuccessful = 200,
-                             perPropertyParallelism = 1)
+      super.checkConfig
+        .withMinimumSuccessful(200)
+        .withPerPropertyParallelism(1)
 
     override def partiallyAppliedForall: PartiallyAppliedForall =
       forall.withConfig(configOverride)
@@ -139,8 +144,10 @@ object Meta {
     override def partiallyAppliedForall: PartiallyAppliedForall = forall
 
     override def checkConfig =
-      super.checkConfig.copy(minimumSuccessful = 100,
-                             // to avoid overcounting of discarded checks
-                             perPropertyParallelism = 1)
+      super.checkConfig
+        .withMinimumSuccessful(100)
+        .withPerPropertyParallelism(
+          1
+        ) // to avoid overcounting of discarded checks
   }
 }

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -36,9 +36,18 @@ object PropertyDogFoodTest extends IOSuite {
             ("2", "0")
           }
 
-        val expectedMessage =
-          s"""Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value"""
-        expect(log.contains(expectedMessage))
+        val actualLines = log.split(System.lineSeparator()).toList
+        val expectedLines = s"""foobar
+          |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+          |You can reproduce this by adding the following override to your suite:
+          |
+          |override def checkConfig = super.checkConfig.withInitialSeed(Seed.fromBase64("$seed").toOption)"""
+          .stripMargin
+          .linesIterator.toList
+
+        forEach(actualLines.zip(expectedLines))({ case (actual, expected) =>
+          expect(actual.contains(expected))
+        })
       }
     }
   }

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -25,23 +25,19 @@ object PropertyDogFoodTest extends IOSuite {
         case LoggedEvent.Error(msg) => msg
       }
       exists(errorLogs) { log =>
+        val seed = Meta.FailedChecks.initialSeed.toBase64
         // Go into software engineering they say
         // Learn how to make amazing algorithms
         // Build robust and deterministic software
-        val (attempt, value, seed) =
+        val (attempt, value) =
           if (ScalaCompat.isScala3) {
-            ("4",
-             "-2147483648",
-             """Seed.fromBase64("AkTFK0oQzv-BOkf-rqnsdb_Etapzkj9gQD9rHj7UnKM=")""")
+            ("4", "-2147483648")
           } else {
-            ("2",
-             "0",
-             """Seed.fromBase64("Nj62qCHF96VYEMGcD2OBlfmuyihbPQQhQLH9acYL5RA=")""")
+            ("2", "0")
           }
 
         val expectedMessage =
-          s"Property test failed on try $attempt with seed $seed and input $value"
-
+          s"""Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value"""
         expect(log.contains(expectedMessage))
       }
     }
@@ -109,10 +105,11 @@ object Meta {
 
   object FailedChecks extends SimpleIOSuite with Checkers {
 
+    val initialSeed = Seed(5L)
     override def checkConfig: CheckConfig =
       super.checkConfig
         .withPerPropertyParallelism(1)
-        .withInitialSeed(Some(Seed(5L)))
+        .withInitialSeed(Some(initialSeed))
 
     test("foobar") {
       forall { (x: Int) =>


### PR DESCRIPTION
This PR:
 - Resolves https://github.com/disneystreaming/weaver-test/issues/632
 - Resolves https://github.com/disneystreaming/weaver-test/issues/338
 - Refactors the `Checkers.forall_` logic, in particular the stream.
