### PR TITLE
Remove assert.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Expectations.scala
+++ b/modules/core/shared/src/main/scala/weaver/Expectations.scala
@@ -163,7 +163,6 @@ object Expectations {
      * Expect macros
      */
     def expect = new Expect
-    def assert = new Expect
 
     val success: Expectations = Monoid[Expectations].empty
 


### PR DESCRIPTION
This PR resolves #67 by removing the `assert` call entirely.

An attempt was made to make `assert` throw in #68 , however the `assert` function didn't compose well. Existing users of `assert` would need to rewrite their code to use `expect`, or use `assert` but with poorer syntax. For example:

```scala
pureTest("some test") {
  assert(1 == 1)
}
```
would need to be written as
```scala
pureTest("some test") {
  assert(1 == 1)
  success
}
```

Instead, we can remove `assert` entirely in favour of `expect`. As a follow up, we can have a scalafix rule to help users migrate.