### PR TITLE
Remove references to Disney.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,19 @@
-Copyright 2020 Disney Streaming Services
+Copyright 2024 Typelevel and respective contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--------------------------------------------------------------------------
+Copyright 2020-2024 Disney Streaming Services
 
   Licensed under the Apache License, Version 2.0 (the "Apache License")
   with the following modification; you may not use this file except in

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 respective contributors
+Copyright 2024 Typelevel
 Copyright 2020-2024 Disney Streaming Services
 
   Licensed under the Apache License, Version 2.0 (the "Apache License")

--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,4 @@
-Copyright 2024 Typelevel and respective contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
---------------------------------------------------------------------------
+Copyright 2024 respective contributors
 Copyright 2020-2024 Disney Streaming Services
 
   Licensed under the Apache License, Version 2.0 (the "Apache License")

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-<img src="https://github.com/disneystreaming/weaver-test/raw/main/website/static/img/logo.png" width="200px" height="231px" align="right">
+<img src="https://github.com/typelevel/weaver-test/raw/main/docs/assets/logo.png" width="200px" height="231px" align="right">
 
-[![CI](https://github.com/disneystreaming/weaver-test/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/disneystreaming/weaver-test/actions/workflows/ci.yml)
-[![Latest version](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-core/latest.svg?color=orange)](https://index.scala-lang.org/disneystreaming/weaver-test/weaver-core)
-[![Gitter](https://img.shields.io/gitter/room/disneystreaming/weaver-test.svg)](https://gitter.im/disneystreaming/weaver-test)
-[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
-[![CLA assistant](https://cla-assistant.io/readme/badge/disneystreaming/weaver-test)](https://cla-assistant.io/disneystreaming/weaver-test)
-
+[![CI](https://github.com/typelevel/weaver-test/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/typelevel/weaver-test/actions/workflows/ci.yml)
+[![Latest version](https://index.scala-lang.org/typelevel/weaver-test/weaver-core/latest.svg?color=orange)](https://index.scala-lang.org/typelevel/weaver-test/weaver-core)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/xQETVDrGxy)
+[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://github.com/scala-steward-org/scala-steward)
 # Weaver-test
 
 A test-framework built on [cats-effect](https://github.com/typelevel/cats-effect) and
@@ -17,14 +15,14 @@ Weaver-test is currently published for **Scala 2.12, 2.13, and 3.0**
 
 ### SBT
 
-Refer yourself to the [releases](https://github.com/disneystreaming/weaver-test/releases) page to know the latest released version, and add the following (or scoped equivalent) to your `build.sbt` file.
+Refer yourself to the [releases](https://github.com/typelevel/weaver-test/releases) page to know the latest released version, and add the following (or scoped equivalent) to your `build.sbt` file.
 
 ```scala
-libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "x.y.z" % Test
+libraryDependencies += "org.typelevel" %% "weaver-cats" % "x.y.z" % Test
 testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 
 // optionally (for Scalacheck usage)
-libraryDependencies +=  "com.disneystreaming" %% "weaver-scalacheck" % "x.y.z" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-scalacheck" % "x.y.z" % Test
 ```
 
 ## Motivation
@@ -247,7 +245,6 @@ Note that the site will look a tiny bit different because to build a versioned w
 
 Please:
 
-- Sign the CLA
 - Write positive and negative tests
 - Include documentation
 

--- a/docs/faqs/other_effects.md
+++ b/docs/faqs/other_effects.md
@@ -9,7 +9,7 @@ to resurrect support for the effect types they use in repository they control.
 
 You can read about the rationale for decision [here](https://github.com/disneystreaming/weaver-test/discussions/570). Feel free to ping us via a github discussion, if you seek to resurrect support for a given effect-type.
 
-If you are looking for documentation of the maintenance branch of weaver that did support other effect types, you can find it [over there](https://disneystreaming.github.io/weaver-test/docs/0.6.15/installation).
+If you are looking for documentation of the maintenance branch of weaver that did support other effect types, you can find it [over there](https://github.com/disneystreaming/weaver-test/blob/v0.6.15/docs/installation.md).
 
 We will try to fix critical bugs on the 0.6/0.7 series, as they get found.
 

--- a/docs/features/discipline.md
+++ b/docs/features/discipline.md
@@ -9,14 +9,14 @@ You'll need to install an additional dependency in order to use Discipline with 
 
 ### SBT
 ```scala
-libraryDependencies +=  "com.disneystreaming" %% "weaver-discipline" % "@VERSION@" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-discipline" % "@VERSION@" % Test
 ```
 
 ### Mill
 ```scala
 object test extends Tests {
   def ivyDeps = Agg(
-    ivy"com.disneystreaming::weaver-discipline:@VERSION@"
+    ivy"org.typelevel::weaver-discipline:@VERSION@"
   )
 }
 ```

--- a/docs/features/scalacheck.md
+++ b/docs/features/scalacheck.md
@@ -9,14 +9,14 @@ You'll need to install an additional dependency in order to use ScalaCheck with 
 
 ### SBT
 ```scala
-libraryDependencies +=  "com.disneystreaming" %% "weaver-scalacheck" % "@VERSION@" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-scalacheck" % "@VERSION@" % Test
 ```
 
 ### Mill
 ```scala
 object test extends Tests {
   def ivyDeps = Agg(
-    ivy"com.disneystreaming::weaver-scalacheck:@VERSION@"
+    ivy"org.typelevel::weaver-scalacheck:@VERSION@"
   )
 }
 ```

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -8,7 +8,7 @@ You'll need to install the following dependencies to test your programs against 
 Newer versions of SBT have [`weaver` automatically integrated](https://github.com/sbt/sbt/pull/7263).
 
 ```scala
-libraryDependencies +=  "com.disneystreaming" %% "weaver-cats" % "@VERSION@" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-cats" % "@VERSION@" % Test
 ```
 
 ### SBT (older versions)
@@ -16,7 +16,7 @@ libraryDependencies +=  "com.disneystreaming" %% "weaver-cats" % "@VERSION@" % T
 Internally, SBT has a hardcoded list of test frameworks it integrates with. `weaver` must be manually added to this list.
 
 ```scala
-libraryDependencies +=  "com.disneystreaming" %% "weaver-cats" % "@VERSION@" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-cats" % "@VERSION@" % Test
 testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 ```
 
@@ -24,7 +24,7 @@ testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 ```scala
 object test extends Tests {
   def ivyDeps = Agg(
-    ivy"com.disneystreaming::weaver-cats:@VERSION@"
+    ivy"org.typelevel::weaver-cats:@VERSION@"
   )
   def testFramework = "weaver.framework.CatsEffect"
 }
@@ -32,7 +32,7 @@ object test extends Tests {
 
 ### scala-cli
 ```scala
-//> using lib "com.disneystreaming::weaver-cats:@VERSION@"
+//> using lib "org.typelevel::weaver-cats:@VERSION@"
 //> using testFramework "weaver.framework.CatsEffect" // this may neccessary if you have other TestFramework on your dependencies
 ```
 


### PR DESCRIPTION
This PR renames references from `com.disneystreaming` to `org.typelevel`.

In addition:
 - The CLA assistant link and reference has been removed.
 - Gitter has been replaced with a link to `weaver-dev` on Discord. We'd want to link to a `weaver` channel once created.

The codebase still references issues and discussions on the `disneystreaming/weaver-test` repo. These are the only references to disney that remain.
