### PR TITLE
Checkout `lfs` assets in the pages build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -103,6 +106,9 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -237,13 +243,16 @@ jobs:
 
   dependency-submission:
     name: Submit Dependencies
-    if: github.event_name != 'pull_request'
+    if: github.event.repository.fork == false && github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -301,6 +310,9 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -324,7 +336,7 @@ jobs:
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3.9.3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: site/target/docs/site

--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ yarn start
 
 If you're only changing `.md` files, you can run `sbt '~docs/mdoc'`.
 
+If you want to view images, such as the logo, use `git lfs` to check them out:
+
+```bash
+git lfs install --local
+git lfs pull
+```
+
 Note that the site will look a tiny bit different because to build a versioned website we have some machinery in the script running on CI - but you don't have to worry about that.
 
 ### PR Guidelines

--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ ThisBuild / developers := List(
 
 ThisBuild / tlCiHeaderCheck := false
 
-// publish to s01.oss.sonatype.org (set to true to publish to oss.sonatype.org instead)
-ThisBuild / tlSonatypeUseLegacyHost := false
+// publish to s01.oss.sonatype.org
+ThisBuild / sonatypeCredentialHost := Sonatype.sonatypeLegacy
 
 // enable the sbt-typelevel-site laika documentation
 ThisBuild / tlSitePublishBranch := Some("main")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,9 +5,9 @@ addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.16.0"
 
 addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.4.17")
 
-addSbtPlugin("org.typelevel"        % "sbt-typelevel"                 % "0.7.0")
+addSbtPlugin("org.typelevel"        % "sbt-typelevel"                 % "0.7.4")
 
-addSbtPlugin("org.typelevel"        % "sbt-typelevel-site"            % "0.7.0")
+addSbtPlugin("org.typelevel"        % "sbt-typelevel-site"            % "0.7.4")
 
 addSbtPlugin("org.scalameta"        % "sbt-scalafmt"                  % "2.5.2")
 


### PR DESCRIPTION
The current pages build doesn't pull assets from `lfs`. This means we can't see the logo on the website:
![image](https://github.com/user-attachments/assets/720aa4dc-1fcd-4a32-8c89-1357d298daeb)

Checking out the `lfs: true` according to the [github docs](https://github.com/actions/checkout?tab=readme-ov-file#usage) should resolve this. 

This isn't supported easily in `sbt-typelevel-site`, so we tweak the parameters of the checkout step using the recently added `updatedParams` function.