### PR TITLE
Fail property test when discard count exceeds `maximumDiscarded`

### DIFF
--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -176,7 +176,7 @@ trait Checkers {
     def shouldStop(config: CheckConfig) =
       failure.isDefined ||
         succeeded >= config.minimumSuccessful ||
-        discarded >= config.maximumDiscarded
+        discarded > config.maximumDiscarded
 
     def shouldContinue(config: CheckConfig) = !shouldStop(config)
 

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -64,13 +64,13 @@ object PropertyDogFoodTest extends IOSuite {
 
   test("Config can be overridden") { dogfood =>
     expectErrorMessage(
-      s"Discarded more inputs (${Meta.ConfigOverrideChecks.configOverride.maximumDiscarded}) than allowed",
+      s"Discarded more inputs (${Meta.ConfigOverrideChecks.configOverride.maximumDiscarded + 1}) than allowed",
       dogfood.runSuite(Meta.ConfigOverrideChecks))
   }
 
   test("Discarded counts should be accurate") { dogfood =>
     expectErrorMessage(
-      s"Discarded more inputs (${Meta.DiscardedChecks.checkConfig.maximumDiscarded}) than allowed",
+      s"Discarded more inputs (${Meta.DiscardedChecks.checkConfig.maximumDiscarded + 1}) than allowed",
       dogfood.runSuite(Meta.DiscardedChecks))
   }
   test("Discard ratio of zero should still run tests") {
@@ -184,7 +184,7 @@ object Meta {
 
     override def checkConfig =
       super.checkConfig
-        .withMinimumSuccessful(1)
+        .withMinimumSuccessful(5)
         // Set the discard ratio to 0. No discarded tests are permitted.
         .withMaximumDiscardRatio(0)
         .withPerPropertyParallelism(


### PR DESCRIPTION
Property tests with a `maximumDiscarded` value of zero fail without running any tests. This is a bug introduced by the stream refactors in https://github.com/typelevel/weaver-test/pull/39. 

This is because the status stream now outputs an initial empty `Status.start` value which satisfies the `discard <= maximumDiscarded` stop condition.

Prior to the refactor, the stream wouldn't output the `Status.start` value, so a single test would be run before the condition was checked. This behaviour was also odd: even if no values were actually discarded, the property test could fail with a discard error.

This PR alters the discard behaviour. The discard count must exceed the `maximumDiscarded` value, not be equal to it. This means that if a `maximumDiscarded` value of `0` is set, then the test will fail if `1` value is discarded.