### PR TITLE
Publish to s01 sonatype host.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,6 @@ ThisBuild / developers := List(
 
 ThisBuild / tlCiHeaderCheck := false
 
-// publish to s01.oss.sonatype.org
-ThisBuild / sonatypeCredentialHost := Sonatype.sonatypeLegacy
-
 // enable the sbt-typelevel-site laika documentation
 ThisBuild / tlSitePublishBranch := Some("main")
 


### PR DESCRIPTION
PR #78 accidentally changed the publishing host to the legacy host.  This PR removes the setting.

The `sbt-typelevel` plugin now publishes to the `s01` host by default, so no explicit settings are necessary.