### PR TITLE
Set tlBaseVersion to 0.9.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import _root_.cats.syntax.all.*
+import com.typesafe.tools.mima.core.{ MissingClassProblem, ProblemFilters }
 import laika.helium.config.TextLink
 import laika.helium.config.ReleaseInfo
 import laika.helium.config.HeliumIcon
@@ -78,7 +79,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     shadedDependencies += "org.scalameta" %%% "munit-diff" % "<ignored>",
     shadingRules += ShadingRule.moveUnder("munit.diff",
                                           "weaver.internal.shaded"),
-    validNamespaces ++= Set("weaver", "org")
+    validNamespaces ++= Set("weaver", "org"),
+    mimaBinaryIssueFilters += ProblemFilters.exclude[MissingClassProblem](
+      "weaver.internal.shaded.*")
   ).enablePlugins(ShadingPlugin)
 
 lazy val coreJVM = core.jvm


### PR DESCRIPTION
We should bump the `tlBaseVersion`, before releasing according to the [sbt-typelevel FAQ](https://typelevel.org/sbt-typelevel/faq.html#how-do-i-cut-a-release).

Note that the MIMA check ran because we have a `0.9.0` tag released. It seems to run on the jar before shading, so fails to detect the shaded `munit-diff` classes. I think we can safely exclude these from MIMA.