### PR TITLE
Add an FAQ about the stewardship change

### DIFF
--- a/docs/faqs/directory.conf
+++ b/docs/faqs/directory.conf
@@ -1,5 +1,6 @@
 laika.title = Frequently Asked Questions
 laika.navigationOrder = [
+  typelevel_stewardship.md
   ide_faqs.md,
   other_effects.md
 ]

--- a/docs/faqs/typelevel-stewardship.md
+++ b/docs/faqs/typelevel-stewardship.md
@@ -1,0 +1,11 @@
+# Why has the organization changed?
+
+The stewardship of weaver has moved from `disneystreaming` to `typelevel`.
+
+Weaver makes heavy use of the `cats-effect` and `fs2` Typelevel projects. These enable weaver to run tests concurrently, provide safe resource handling, composable assertions and much more. By becoming part of the Typelevel umbrella, weaver can be maintained more easily alongside its core dependencies.
+
+The new weaver project is licensed under Apache 2.0 and requires no CLA for contributions.
+
+## Migrating from `org.disneystreaming` 
+
+If you use [Scala Steward](https://github.com/scala-steward-org/scala-steward), you will migrate automatically. If not, read the [`0.9.0` migration guide](https://github.com/typelevel/weaver-test/releases/tag/v0.9.0).

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -1,6 +1,12 @@
 Installation
 ============
 
+@:callout(info)
+The stewardship of Weaver has moved from `disneystreaming` to `typelevel`.
+
+You can migrate from previous versions of weaver by following the [migration guide](https://github.com/typelevel/weaver-test/releases/tag/v0.9.0), or [learn more about the stewardship](../faqs/typelevel-stewardship.md).
+@:@
+
 You'll need to install the following dependencies to test your programs against `cats.effect.IO`
 
 ### SBT (1.9.0+)


### PR DESCRIPTION
Users might find the site first before coming across the migration notes. 

This PR adds a note in the `Installation` page about the migration and a short FAQ about the org change.

## Installation note
<img width="932" alt="image" src="https://github.com/user-attachments/assets/fbec70ca-9042-4aa6-aa24-2928e5ef56a3" />

## FAQ
<img width="932" alt="image" src="https://github.com/user-attachments/assets/c9d9252e-bfb7-4df5-a1ac-df468943b429" />
