### PR TITLE
Direct users towards clue function.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
@@ -59,7 +59,7 @@ object Clues {
       val cluesMessage = if (clueList.nonEmpty) {
         val lines = clueList.map(clue => s"  ${clue.prettyPrint}")
         lines.mkString("Clues {\n", "\n", "\n}")
-      } else ""
+      } else "Use the `clue` function to troubleshoot"
       val fullMessage = header + "\n\n" + cluesMessage
 
       val exception =


### PR DESCRIPTION
We've removed expecty in favour of `clue`, but don't direct people towards it.

This changes the `assertion failed` error message. 

# Previous error message

<img width="827" alt="image" src="https://github.com/user-attachments/assets/6a61f8d0-5b56-4d6d-b462-05d90f7a2614" />

# New error message
<img width="827" alt="image" src="https://github.com/user-attachments/assets/f7b9b781-b861-435d-9f02-b0bf666ea4cb" />

