### PR TITLE
Improve failure message of `expect.all`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import laika.config.LinkValidation
 import org.typelevel.sbt.site.TypelevelSiteSettings
 import sbt.librarymanagement.Configurations.ScalaDocTool
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.9" // your current series x.y
+ThisBuild / tlBaseVersion := "0.10" // your current series x.y
 
 ThisBuild / startYear := Some(2019)
 ThisBuild / licenses  := Seq(License.Apache2)

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import laika.config.LinkValidation
 import org.typelevel.sbt.site.TypelevelSiteSettings
 import sbt.librarymanagement.Configurations.ScalaDocTool
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.10" // your current series x.y
+ThisBuild / tlBaseVersion := "0.9" // your current series x.y
 
 ThisBuild / startYear := Some(2019)
 ThisBuild / licenses  := Seq(License.Apache2)

--- a/modules/core/shared/src/main/scala-2/weaver/ExpectMacro.scala
+++ b/modules/core/shared/src/main/scala-2/weaver/ExpectMacro.scala
@@ -46,11 +46,14 @@ private[weaver] object ExpectMacro {
         val clueMethodSymbol         = getClueMethodSymbol(c)
         val transformedValue =
           replaceClueMethodCalls(c)(clueMethodSymbol, cluesName, value)
+        val sourceCode =
+          new String(value.pos.source.content.slice(value.pos.start,
+                                                    value.pos.end))
         makeExpectations(c)(cluesName,
                             cluesValDef,
                             transformedValue,
                             sourceLoc,
-                            message = q"None",
+                            message = q"Some($sourceCode)",
                             indexAndTotalNumberOfAssertions =
                               q"Some(($index, $total))")
       }

--- a/modules/core/shared/src/main/scala-2/weaver/ExpectMacro.scala
+++ b/modules/core/shared/src/main/scala-2/weaver/ExpectMacro.scala
@@ -39,9 +39,9 @@ private[weaver] object ExpectMacro {
   def allImpl(c: blackbox.Context)(values: c.Tree*): c.Tree = {
     import c.universe._
     val sourceLoc = new weaver.macros.Macros(c).fromContext.asInstanceOf[c.Tree]
+    val clueMethodSymbol = getClueMethodSymbol(c)
     val allExpectations = values.toList.map { value =>
       val (cluesName, cluesValDef) = makeClues(c)
-      val clueMethodSymbol         = getClueMethodSymbol(c)
       val transformedValue =
         replaceClueMethodCalls(c)(clueMethodSymbol, cluesName, value)
       val sourceCode =

--- a/modules/core/shared/src/main/scala-3/weaver/ExpectMacro.scala
+++ b/modules/core/shared/src/main/scala-3/weaver/ExpectMacro.scala
@@ -55,7 +55,7 @@ private[weaver] object ExpectMacro {
     '{
       val clues  = new Clues
       val result = ${ assertion }(using clues)
-      Clues.toExpectations($sourceLoc, None, clues, None, result)
+      Clues.toExpectations($sourceLoc, None, clues, result)
     }
   }
 
@@ -72,7 +72,7 @@ private[weaver] object ExpectMacro {
     '{
       val clues  = new Clues
       val result = ${ assertion }(using clues)
-      Clues.toExpectations($sourceLoc, Some($message), clues, None, result)
+      Clues.toExpectations($sourceLoc, Some($message), clues, result)
     }
   }
 
@@ -91,7 +91,6 @@ private[weaver] object ExpectMacro {
       case _              => Nil
     })
     '{
-      val totalNumberOfAssertions = ${ assertions }.size
       val expectations =
         ${ assertions }.zipWithIndex.map { case (assertion, index) =>
           val clues      = new Clues
@@ -100,7 +99,6 @@ private[weaver] object ExpectMacro {
           Clues.toExpectations($sourceLoc,
                                sourceCode,
                                clues,
-                               Some((index, totalNumberOfAssertions)),
                                result)
         }
       expectations.toList.combineAll

--- a/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
@@ -49,17 +49,11 @@ object Clues {
       sourceLoc: SourceLocation,
       message: Option[String],
       clues: Clues,
-      indexAndTotalNumberOfAssertions: Option[(Int, Int)],
       success: Boolean): Expectations = {
     if (success) {
       Expectations(Validated.valid(()))
     } else {
-      val headerPrefix = indexAndTotalNumberOfAssertions match {
-        case Some((index, total)) => s"assertion ${index + 1} of $total failed"
-        case None                 => "assertion failed"
-      }
-
-      val header   = headerPrefix + message.fold("")(msg => s": $msg")
+      val header   = "assertion failed" + message.fold("")(msg => s": $msg")
       val clueList = clues.getClues
       val cluesMessage = if (clueList.nonEmpty) {
         val lines = clueList.map(clue => s"  ${clue.prettyPrint}")

--- a/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
@@ -49,7 +49,8 @@ object Clues {
       sourceLoc: SourceLocation,
       message: Option[String],
       clues: Clues,
-      success: Boolean): Expectations = {
+      results: Boolean*): Expectations = {
+    val success = results.toList.forall(identity)
     if (success) {
       Expectations(Validated.valid(()))
     } else {

--- a/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/Clues.scala
@@ -39,7 +39,7 @@ object Clues {
   /**
    * Constructs [[Expectations]] from the collection of clues.
    *
-   * If the results are successful, the clues are discarded. If any result has
+   * If the result is successful, the clues are discarded. If the result has
    * failed, the clues are printed as part of the failure message.
    *
    * This function is called as part of the expansion of the `expect` macro. It
@@ -49,12 +49,17 @@ object Clues {
       sourceLoc: SourceLocation,
       message: Option[String],
       clues: Clues,
-      results: Boolean*): Expectations = {
-    val success = results.toList.forall(identity)
+      indexAndTotalNumberOfAssertions: Option[(Int, Int)],
+      success: Boolean): Expectations = {
     if (success) {
       Expectations(Validated.valid(()))
     } else {
-      val header   = "assertion failed" + message.fold("")(msg => s": $msg")
+      val headerPrefix = indexAndTotalNumberOfAssertions match {
+        case Some((index, total)) => s"assertion ${index + 1} of $total failed"
+        case None                 => "assertion failed"
+      }
+
+      val header   = headerPrefix + message.fold("")(msg => s": $msg")
       val clueList = clues.getClues
       val cluesMessage = if (clueList.nonEmpty) {
         val lines = clueList.map(clue => s"  ${clue.prettyPrint}")

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -376,14 +376,14 @@ object DogFoodTests extends IOSuite {
         val expected =
           s"""
         |- (all) 0ms
-        | [0] assertion 2 of 5 failed (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [0] assertion 2 of 5 failed: clue(x) == clue(y) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
         | [0] 
         | [0] Clues {
         | [0]   x: Int = 1
         | [0]   y: Int = 2
         | [0] }
         |
-        | [1] assertion 4 of 5 failed (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [1] assertion 4 of 5 failed: clue(y) == clue(z) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
         | [1] 
         | [1] Clues {
         | [1]   y: Int = 2

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -369,21 +369,21 @@ object DogFoodTests extends IOSuite {
         expect.same(expected, actual)
     }
   }
-  test("failures in expect.all are reported with their index") {
+  test("failures in expect.all are reported with their source code") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
         val actual = extractFailureMessageForTest(logs, "(all)")
         val expected =
           s"""
         |- (all) 0ms
-        | [0] assertion 2 of 5 failed: clue(x) == clue(y) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [0] assertion failed: clue(x) == clue(y) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
         | [0] 
         | [0] Clues {
         | [0]   x: Int = 1
         | [0]   y: Int = 2
         | [0] }
         |
-        | [1] assertion 4 of 5 failed: clue(y) == clue(z) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [1] assertion failed: clue(y) == clue(z) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
         | [1] 
         | [1] Clues {
         | [1]   y: Int = 2

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -257,11 +257,7 @@ object DogFoodTests extends IOSuite {
     "expect.eql delegates to Comparison show when an instance is found") {
     _.runSuite(Meta.Rendering).map {
       case (logs, _) =>
-        val actual =
-          extractLogEventAfterFailures(logs) {
-            case LoggedEvent.Error(msg) if msg.contains("(eql Comparison)") =>
-              msg
-          }.get
+        val actual = extractFailureMessageForTest(logs, "(eql Comparison)")
 
         val expected = """
         |- (eql Comparison) 0ms
@@ -280,11 +276,7 @@ object DogFoodTests extends IOSuite {
     "expect.same delegates to Comparison show when an instance is found") {
     _.runSuite(Meta.Rendering).map {
       case (logs, _) =>
-        val actual =
-          extractLogEventAfterFailures(logs) {
-            case LoggedEvent.Error(msg) if msg.contains("(same Comparison)") =>
-              msg
-          }.get
+        val actual = extractFailureMessageForTest(logs, "(same Comparison)")
 
         val expected = """
         |- (same Comparison) 0ms
@@ -319,11 +311,7 @@ object DogFoodTests extends IOSuite {
   test("failures with clues are rendered correctly") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) if msg.contains("(failure)") =>
-            msg
-        }.get
-
+        val actual = extractFailureMessageForTest(logs, "(failure)")
         val expected =
           s"""
         |- (failure) 0ms
@@ -343,11 +331,7 @@ object DogFoodTests extends IOSuite {
   test("failures with nested clues are rendered correctly") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) if msg.contains("(nested)") =>
-            msg
-        }.get
-
+        val actual = extractFailureMessageForTest(logs, "(nested)")
         val expected =
           s"""
         |- (nested) 0ms
@@ -368,10 +352,7 @@ object DogFoodTests extends IOSuite {
   test("failures with identical clue expressions are rendered correctly") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) if msg.contains("(map)") =>
-            msg
-        }.get
+        val actual = extractFailureMessageForTest(logs, "(map)")
 
         val expected =
           s"""
@@ -388,19 +369,40 @@ object DogFoodTests extends IOSuite {
         expect.same(expected, actual)
     }
   }
+  test("failures in expect.all are reported with their index") {
+    _.runSuite(Meta.Clue).map {
+      case (logs, _) =>
+        val actual = extractFailureMessageForTest(logs, "(all)")
+        val expected =
+          s"""
+        |- (all) 0ms
+        | [0] assertion 2 of 5 failed (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [0] 
+        | [0] Clues {
+        | [0]   x: Int = 1
+        | [0]   y: Int = 2
+        | [0] }
+        |
+        | [1] assertion 4 of 5 failed (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        | [1] 
+        | [1] Clues {
+        | [1]   y: Int = 2
+        | [1]   z: Int = 3
+        | [1] }
+        """.stripMargin.trim
+        expect.same(expected, actual)
+    }
+  }
 
   test("values of clues are rendered with the given show") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) if msg.contains("(show)") =>
-            msg
-        }.get
+        val actual = extractFailureMessageForTest(logs, "(show)")
 
         val expected =
           s"""
         |- (show) 0ms
-        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
+        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:109)
         |
         |  Clues {
         |    x: Int = int-1
@@ -416,16 +418,12 @@ object DogFoodTests extends IOSuite {
   test("values of clues are rendered with show constructed from toString if no show is given") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg)
-              if msg.contains("(show-from-to-string)") =>
-            msg
-        }.get
+        val actual = extractFailureMessageForTest(logs, "(show-from-to-string)")
 
         val expected =
           s"""
         |- (show-from-to-string) 0ms
-        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:112)
+        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:119)
         |
         |  Clues {
         |    x: Foo = foo-1
@@ -440,15 +438,12 @@ object DogFoodTests extends IOSuite {
   test("clue calls are replaced when using helper objects") {
     _.runSuite(Meta.Clue).map {
       case (logs, _) =>
-        val actual = extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) if msg.contains("(helpers)") =>
-            msg
-        }.get
+        val actual = extractFailureMessageForTest(logs, "(helpers)")
 
         val expected =
           s"""
         |- (helpers) 0ms
-        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:121)
+        |  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:128)
         |
         |  Clues {
         |    x: Int = 1
@@ -489,6 +484,14 @@ object DogFoodTests extends IOSuite {
       .map(Colours.removeASCIIColors)
       .map(_.trim)
   }
+
+  private def extractFailureMessageForTest(
+      logs: Chain[LoggedEvent],
+      testName: String): String =
+    extractLogEventAfterFailures(logs) {
+      case LoggedEvent.Error(msg) if msg.contains(testName) =>
+        msg
+    }.get
 
   private def extractLogEventAfterFailures(logs: Chain[LoggedEvent])(
       pf: PartialFunction[LoggedEvent, String]): Option[String] = {

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -95,6 +95,13 @@ object Meta {
       expect(List(x, y).map(v => clue(v)) == List(x, x))
     }
 
+    pureTest("(all)") {
+      val x = 1
+      val y = 2
+      val z = 3
+      expect.all(x == x, clue(x) == clue(y), y == y, clue(y) == clue(z), z == z)
+    }
+
     pureTest("(show)") {
       implicit val intShow: Show[Int] = i => s"int-$i"
       val x                           = 1


### PR DESCRIPTION
## Problem
As described in #163 , `expect.all` currently displays a general `assertion failed` message when any assertion fails:

```
assertion failed (Meta.scala:18)

  Use the `clue` function to troubleshoot
```

It doesn't indicate which of the assertions in `expect.all` failed.

## Improvement
This PR adds the source code and index of the assertion into the failure message.

In addition, the collection of clues is assertion-specific. 

## Example failure message

The failing test:
```scala
    pureTest("(all)") {
      val x = 1
      val y = 2
      val z = 3
      expect.all(x == x, clue(x) == clue(y), y == y, clue(y) == clue(z), z == z)
    }
```
Has the message:
```
(all) 0ms
[0] assertion 2 of 5 failed: clue(x) == clue(y) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
[0] 
[0] Clues {
[0]   x: Int = 1
[0]   y: Int = 2
[0] }

[1] assertion 4 of 5 failed: clue(y) == clue(z) (modules/framework-cats/shared/src/test/scala/Meta.scala:102)
[1] 
[1] Clues {
[1]   y: Int = 2
[1]   z: Int = 3
[1] }
```

## Binary compatibility
The `Clues.toExpectations` signature has changed from accepting a `Boolean*` to a `Boolean`. This is source compatible, since no one should be calling it directly. It's not binary compatible, as libraries with `expect` compiled against `0.9.1` will refer to the old `Clues.toExpectations` signature.