### PR TITLE
Update installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,17 @@ A test-framework built on [cats-effect](https://github.com/typelevel/cats-effect
 
 ## Installation
 
-Weaver-test is currently published for **Scala 2.12, 2.13, and 3.0**
+Weaver-test is currently published for **Scala 2.12, 2.13, and 3**
 
-### SBT
+### SBT (1.9.0+)
 
-Refer yourself to the [releases](https://github.com/typelevel/weaver-test/releases) page to know the latest released version, and add the following (or scoped equivalent) to your `build.sbt` file.
+Refer yourself to the [releases](https://github.com/typelevel/weaver-test/releases) page to know the latest released version, and add the following to your `build.sbt` file.
 
 ```scala
-libraryDependencies += "org.typelevel" %% "weaver-cats" % "x.y.z" % Test
-testFrameworks += new TestFramework("weaver.framework.CatsEffect")
-
-// optionally (for Scalacheck usage)
-libraryDependencies +=  "org.typelevel" %% "weaver-scalacheck" % "x.y.z" % Test
+libraryDependencies +=  "org.typelevel" %% "weaver-cats" % "@VERSION@" % Test
 ```
+
+For other build tools and older SBT versions, read the [installation guide](https://typelevel.org/weaver-test/overview/installation.html).
 
 ## Motivation
 

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -7,7 +7,7 @@ The stewardship of Weaver has moved from `disneystreaming` to `typelevel`.
 You can migrate from previous versions of weaver by following the [migration guide](https://github.com/typelevel/weaver-test/releases/tag/v0.9.0), or [learn more about the stewardship](../faqs/typelevel-stewardship.md).
 @:@
 
-You'll need to install the following dependencies to test your programs against `cats.effect.IO`
+Weaver-test is currently published for **Scala 2.12, 2.13, and 3**
 
 ### SBT (1.9.0+)
 


### PR DESCRIPTION
The `README.md` currently instructs developers to add a `TestFramework` to their SBT settings. They only need to do this for older versions of SBT. 

This PR simplifies the installation instructions.