### PR TITLE
Add guide on asserting equality.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,7 @@ lazy val docs = project
   .settings(
     moduleName := "weaver-docs",
     name       := "Weaver documentation",
+    mdocExtraArguments += "--allowCodeFenceIndented",
     watchSources += (ThisBuild / baseDirectory).value / "docs",
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-ember-client" % Version.http4s,

--- a/docs/features/asserting_equality.md
+++ b/docs/features/asserting_equality.md
@@ -1,0 +1,124 @@
+# Asserting equality
+
+```scala mdoc:invisible
+import weaver.Expectations.Helpers._
+val expected = 1
+val found = 2
+```
+
+Weaver offers two approaches for asserting equality: `expect.eql` and `expect.same`.
+
+`expect.eql` is the better approach, but you may need to write some extra code to use it.
+
+## `expect.eql` (recommended)
+
+```scala mdoc:compile-only
+expect.eql(expected, found)
+```
+
+`expect.eql` asserts for strict equality.
+
+If you accidentally compare the wrong types of data, your code will not compile:
+
+```scala mdoc:fail
+expect.eql(1, "one")
+```
+
+The data types you compare must have an [Eq](https://typelevel.org/cats/typeclasses/eq.html) typeclass instance. You can declare one, or derive one using [kittens](https://github.com/typelevel/kittens).
+
+```scala mdoc:compile-only
+case class Pet(name: String)
+
+// A cats.Eq instance is needed
+import cats.Eq
+implicit val petEq: Eq[Pet] = Eq.by(_.name)
+
+expect.eql(Pet("Maru"), Pet("Fido"))
+```
+
+## `expect.same`
+
+```scala mdoc:compile-only
+expect.same(expected, found)
+```
+
+`expect.same` asserts using universal equality. 
+
+If you accidentally compare the wrong types of data, your code will compile. Your test will fail later, when it is run:
+
+```scala
+// This compiles
+expect.same(1, "one")
+```
+
+
+`expect.same` doesn't require an `Eq` instance. 
+
+```scala mdoc:compile-only
+case class Dog(name: String) // No Eq instance defined
+
+expect.same(Dog("Maru"), Dog("Fido"))
+```
+
+## Do not use `expect`
+
+You can assert for equality using `expect`.
+
+```scala mdoc:compile-only
+expect(1 == 2)
+```
+
+This is discouraged because its failure messages are poorer than `expect.eql` or `expect.same`. It does not display a diff of the values on the left and right side of the equality.
+
+Use `expect` along with `clue` when you have other assertions. For example to assert for `>`
+
+```scala mdoc:invisible
+val x = 1
+```
+
+```scala mdoc:compile-only
+expect(clue(x) > 2)
+```
+
+## Should I use `expect.same` or `expect.eql`?
+
+- Use `expect.eql` for Scala standard datatypes such as `Int` and `String`. These have `Eq` instances, so don't need any extra code.
+- Use `expect.eql` for your own data types if you prefer compile time errors at the expense of extra code.
+- Use `expect.same` for your own data types if you prefer runtime test failures instead of extra code.
+
+These are described in the suite below.
+
+### Example suite
+
+```scala mdoc
+import weaver._
+
+object ExpectationsSuite extends SimpleIOSuite {
+
+  pureTest("expect.eql for standard data types") {
+    expect.eql(1, 2)
+  }
+  
+  import cats.Eq
+  case class Pet(name: String)
+  implicit val eqPet: Eq[Pet] = Eq.by[Pet, String](_.name)
+  
+  pureTest("expect.eql for user-defined data types") {
+    expect.same(Pet("Maru"), Pet("Fido"))
+  }
+
+  // Note that we don't have an instance of Eq[Dog]
+  // anywhere in scope
+  case class Dog(name: String)
+
+  pureTest("expect.same relaxed equality comparison") {
+    expect.same(Dog("Maru"), Dog("Fido"))
+  }
+}
+```
+
+### Example suite report
+
+```scala mdoc:passthrough
+println(weaver.docs.Output.runSuites(ExpectationsSuite))
+```

--- a/docs/features/directory.conf
+++ b/docs/features/directory.conf
@@ -1,6 +1,7 @@
 laika.title = Features
 laika.navigationOrder = [
  expectations.md,
+ asserting_equality.md,
  tracing_failures.md,
  resources.md,
  global_resources.md,

--- a/docs/features/expectations.md
+++ b/docs/features/expectations.md
@@ -7,40 +7,58 @@ The easiest way to construct expectactions is to call the `expect` macro. The `c
 
 ## TL;DR
 
-- Assert on boolean values using `expect`: 
-   
-   ```scala mdoc:compile-only
-   expect(myVar == 25 && list.size == 4)
-   ```
+```scala mdoc:invisible
+import weaver.Expectations.Helpers._
+import cats.effect.IO
+val list = List(1)
+```
+
+- Assert on boolean values using `expect`:
+
+  ```scala mdoc:compile-only
+  expect(list.size > 4)
+  ```
 
 - Investigate failures using `clue`:
 
    ```scala mdoc:compile-only
-   expect(clue(myVar) == 25 && clue(list).size == 4)
+   expect(clue(list).size > 4)
    ```
 
-- Compose expectations using `and`/`or`
-  
+- Compare values using `expect.eql` (needs an `Eq` instance)
+
   ```scala mdoc:compile-only
-  (expect(1 == 1) and expect(2 > 1)) or expect(5 == 5)
+  expect.eql(List(1, 2, 3), (1 to 3).toList)
+  ```
+
+- Compare values with relaxed equality using `expect.same` (no `Eq` instance needed)
+
+  ```scala mdoc:compile-only
+  expect.same(List(1, 2, 3), (1 to 3).toList)
+  ```
+
+- Compose expectations using `and`/`or`
+
+  ```scala mdoc:compile-only
+  (expect(1 > 0) and expect(2 > 1)) or expect(5 < 6)
   ```
 
 - ... or their symbolic aliases `&&`/`||`
 
   ```scala mdoc:compile-only
-  (expect(1 == 1) && expect(2 > 1)) || expect(5 == 5)
+  (expect(1 > 0) && expect(2 > 1)) || expect(5 < 6)
   ```
 
 - Compose expectations using `xor`
 
   ```scala mdoc:compile-only
-  expect(1 == 1) xor expect(2 == 2)
+  expect(1 > 0) xor expect(2 > 1)
   ```
 
 - Use varargs short form for asserting on all boolean values
 
   ```scala mdoc:compile-only
-  expect.all(1 == 1, 2 == 2, 3 > 2)
+  expect.all(1 > 0, 2 > 1, 3 > 2)
   ```
 
 - Use `forEach` to test every element of a collection (or anything that
@@ -76,25 +94,6 @@ The easiest way to construct expectactions is to call the `expect` macro. The `c
   }
   ```
 
-- Use `expect.eql` for strict equality comparison (types that implement `Eq`
-    typeclass) and string representation diffing (using `Show` typeclass, fall
-    back to `toString` if no instance found) in
-    case of failure
-
-  ```scala mdoc:compile-only
-  expect.eql(List(1, 2, 3), (1 to 3).toList)
-  ```
-
-  See below how the output looks in case of failure
-
-- Use `expect.same` for relaxed equality comparison (if no `Eq` instance is
-    found, fall back to universal equality) and relaxed string diffing (fall
-    back to `toString` implementation)
-
-  ```scala mdoc:compile-only
-  expect.same(List(1, 2, 3), (1 to 3).toList)
-  ```
-
 - Use `success` or `failure` to create succeeding/failing expectations without
     conditions
 
@@ -107,9 +106,9 @@ The easiest way to construct expectactions is to call the `expect` macro. The `c
   ```scala mdoc:compile-only
   for {
     x <- IO("hello")
-    _ <- expect(x.length == 4).failFast
+    _ <- expect(x.length < 4).failFast[IO]
     y = x + "bla"
-    _ <- expect(y.size > x.size).failFast
+    _ <- expect(y.size > x.size).failFast[IO]
   } yield expect(y.contains(x))
   ```
 
@@ -121,54 +120,47 @@ import cats.effect.IO
 
 object ExpectationsSuite extends SimpleIOSuite {
 
-  object A {
-    object B {
-      object C {
-        def test(a: Int) = a + 5
-      }
-    }
-  }
+  def test(a: Int) = a + 5
 
   pureTest("Simple expectations (success)") {
     val z = 15
-    
-    expect(A.B.C.test(z) == z + 5)
-  }
-  
-  pureTest("Simple expectations (failure)") {
-    val z = 15
-    
-    expect(clue(A.B.C.test(z)) % 7 == 0)
+
+    expect(test(z) < z + 6)
   }
 
+  pureTest("Simple expectations (failure)") {
+    val z = 15
+
+    expect(clue(test(z)) > z + 6)
+  }
 
   pureTest("And/Or composition (success)") {
     expect(1 != 2) and expect(2 != 1) or expect(2 != 3)
   }
 
   pureTest("And/Or composition (failure)") {
-    (expect(1 != clue(2)) and expect(2 == clue(1))) or expect(2 == clue(3))
+    (expect(1 != clue(2)) and expect(2 < clue(1))) or expect(2 > clue(3))
   }
 
   pureTest("Varargs composition (success)") {
-    // expect(1 + 1 == 2) && expect (2 + 2 == 4) && expect(4 * 2 == 8)
-    expect.all(1 + 1 == 2, 2 + 2 == 4, 4 * 2 == 8)
+    // expect(1 + 1 < 3) && expect(2 + 2 < 5) && expect(4 * 2 < 9)
+    expect.all(1 + 1 < 3, 2 + 2 < 5, 4 * 2 < 9)
   }
 
   pureTest("Varargs composition (failure)") {
-    // expect(1 + 1 == 2) && expect (2 + 2 == 4) && expect(4 * 2 == 8)
-    expect.all(clue(1 + 1) == 2, clue(2 + 2) == 5, clue(4 * 2) == 8)
+    // expect(1 + 1 < 3) && expect(clue(2 + 2) > 5) && expect(4 * 2 < 9)
+    expect.all(1 + 1 < 3, clue(2 + 2) > 5, 4 * 2 < 9)
   }
 
   pureTest("Working with collections (success)") {
     forEach(List(1, 2, 3))(i => expect(i < 5)) and
-      forEach(Option("hello"))(msg => expect.same(msg, "hello")) and
-      exists(List("a", "b", "c"))(i => expect(i == "c")) and
-      exists(Vector(true, true, false))(i => expect(i == false))
+      forEach(Option("hello"))(msg => expect.eql(msg, "hello")) and
+      exists(List("a", "b", "c"))(i => expect.eql(i, "c")) and
+      exists(Vector(true, true, false))(i => expect.eql(i, false))
   }
 
   pureTest("Working with collections (failure 1)") {
-    forEach(Vector("hello", "world"))(msg => expect.same(msg, "hello"))
+    forEach(Vector("hello", "world"))(msg => expect.eql(msg, "hello"))
   }
 
   pureTest("Working with collections (failure 2)") {
@@ -183,7 +175,7 @@ object ExpectationsSuite extends SimpleIOSuite {
   pureTest("Strict equality (success)") {
     expect.eql("hello", "hello") and
       expect.eql(List(1, 2, 3), List(1, 2, 3)) and
-      expect.eql(Test(25.0), Test(25.0))  
+      expect.eql(Test(25.0), Test(25.0))
   }
 
   pureTest("Strict equality (failure 1)") {
@@ -203,17 +195,17 @@ object ExpectationsSuite extends SimpleIOSuite {
   class Hello(val d: Double) {
     override def toString = s"Hello to $d"
 
-    override def equals(other: Any) = 
+    override def equals(other: Any) =
       if(other != null && other.isInstanceOf[Hello])
         other.asInstanceOf[Hello].d == this.d
-      else 
+      else
         false
   }
 
   pureTest("Relaxed equality comparison (success)") {
     expect.same(new Hello(25.0), new Hello(25.0))
   }
-  
+
   pureTest("Relaxed equality comparison (failure)") {
     expect.same(new Hello(25.0), new Hello(50.0))
   }


### PR DESCRIPTION
This PR adds docs for asserting equality.

It also updates the `TLDR` expectations page to avoid using `==` in `expect`.

<img width="705" alt="image" src="https://github.com/user-attachments/assets/55d4448d-bcd4-4a15-a976-eb35d8dd508c" />
<img width="705" alt="image" src="https://github.com/user-attachments/assets/5c7b15de-dcfc-4029-b36e-5d5fe61a2be9" />
<img width="697" alt="image" src="https://github.com/user-attachments/assets/490a58f4-3933-442a-a5a6-10df93210ac1" />
<img width="697" alt="image" src="https://github.com/user-attachments/assets/9ebcc844-b93d-4ecd-ab20-dde7b4923d22" />
