### PR TITLE
Print source code for all failures

### DIFF
--- a/modules/core/shared/src/main/scala-2/weaver/SourceLocationMacro.scala
+++ b/modules/core/shared/src/main/scala-2/weaver/SourceLocationMacro.scala
@@ -3,6 +3,7 @@ package weaver
 // kudos to https://github.com/monix/minitest
 // format: off
 import scala.reflect.macros.blackbox
+import weaver.internals.SourceCode
 
 trait SourceLocationMacro {
 
@@ -26,15 +27,19 @@ object macros {
     import c.universe._
 
     def fromContext: c.Tree = {
-      val (pathExpr, relPathExpr, lineExpr) = getSourceLocation
+      val (pathExpr, relPathExpr, lineExpr, lineSourceExpr) = getSourceLocation
       val SourceLocationSym = symbolOf[SourceLocation].companion
-      q"""$SourceLocationSym($pathExpr, $relPathExpr, $lineExpr)"""
+      q"""$SourceLocationSym($pathExpr, $relPathExpr, $lineExpr, $lineSourceExpr)"""
     }
 
     private def getSourceLocation = {
       val pwd  = java.nio.file.Paths.get("").toAbsolutePath
       val p = c.enclosingPosition.source.path
       val abstractFile = c.enclosingPosition.source.file
+      val line = c.enclosingPosition.line
+      val lineContent = SourceCode.sanitize(c)(c.enclosingPosition.source.lineToString(line - 1))
+      val column = c.enclosingPosition.column
+      val lineSourceExpr = q"Some(($lineContent, $column))"
 
       // Comparing roots to workaround a Windows-specific behaviour
       // https://github.com/disneystreaming/weaver-test/issues/364
@@ -42,8 +47,8 @@ object macros {
         pwd.relativize(abstractFile.file.toPath()).toString()
       } else p
 
-      val line = c.Expr[Int](Literal(Constant(c.enclosingPosition.line)))
-      (p, rp, line)
+      val lineExpr = c.Expr[Int](Literal(Constant(line)))
+      (p, rp, lineExpr, lineSourceExpr)
     }
 
   }

--- a/modules/core/shared/src/main/scala-3/weaver/SourceLocationMacro.scala
+++ b/modules/core/shared/src/main/scala-3/weaver/SourceLocationMacro.scala
@@ -25,6 +25,13 @@ object macros {
     val pwd  = java.nio.file.Paths.get("").toAbsolutePath
 
     val position = Position.ofMacroExpansion
+    val lineSource = position.sourceFile.content.map { content =>
+      val lineContentBefore = content.slice(0, position.end).split("\\r?\\n").last
+      val lineContentAfter = content.drop(position.end).split("\\r?\\n").head
+      val column = lineContentBefore.length
+      (s"$lineContentBefore$lineContentAfter", column)
+    }
+    val lineSourceExpr = Expr(lineSource)
 
     val psj = position.sourceFile.getJPath.getOrElse(Paths.get(position.sourceFile.path))
     // Comparing roots to workaround a Windows-specific behaviour
@@ -33,7 +40,7 @@ object macros {
     val absPath = Expr(psj.toAbsolutePath.toString)
     val l = Expr(position.startLine + 1)
 
-    '{SourceLocation($absPath, $rp, $l) }
+    '{SourceLocation($absPath, $rp, $l, $lineSourceExpr) }
   }
 }
 

--- a/modules/core/shared/src/main/scala/weaver/Result.scala
+++ b/modules/core/shared/src/main/scala/weaver/Result.scala
@@ -205,7 +205,7 @@ object Result {
     val lines = locations.flatMap { l =>
       val prefix = s"${l.fileRelativePath}:${l.line}"
       l.sourceCode.fold(List.empty[String]) { sourceCode =>
-        val pointer = List.fill(sourceCode.column - 1)(" ").mkString + "^"
+        val pointer = " " * (sourceCode.column - 1) + "^"
         List(prefix, sourceCode.sourceLine, pointer)
       }
     }

--- a/modules/core/shared/src/main/scala/weaver/Result.scala
+++ b/modules/core/shared/src/main/scala/weaver/Result.scala
@@ -164,7 +164,8 @@ object Result {
       color: String,
       prefix: String): String = {
 
-    val lines = message.split("\\r?\\n").zipWithIndex.map {
+    val footer = locationFooter(location)
+    val lines = (message.split("\\r?\\n") ++ footer).zipWithIndex.map {
       case (line, index) =>
         if (index == 0)
           color + prefix + line +
@@ -184,7 +185,8 @@ object Result {
       color: String,
       width: Tabulation): String = {
 
-    val lines = message.split("\\r?\\n").zipWithIndex.map {
+    val footer = locationFooter(location)
+    val lines = (message.split("\\r?\\n") ++ footer).zipWithIndex.map {
       case (line, index) =>
         val prefix = if (line.trim == "") "" else width.prefix
         if (index == 0)
@@ -197,5 +199,16 @@ object Result {
     }
 
     lines.mkString(EOL) + Console.RESET
+  }
+
+  private def locationFooter(locations: List[SourceLocation]): List[String] = {
+    val lines = locations.flatMap { l =>
+      val prefix = s"${l.fileRelativePath}:${l.line}"
+      l.sourceCode.fold(List.empty[String]) { sourceCode =>
+        val pointer = List.fill(sourceCode.column - 1)(" ").mkString + "^"
+        List(prefix, sourceCode.sourceLine, pointer)
+      }
+    }
+    if (lines.nonEmpty) "" :: lines else Nil
   }
 }

--- a/modules/core/shared/src/main/scala/weaver/SourceLocation.scala
+++ b/modules/core/shared/src/main/scala/weaver/SourceLocation.scala
@@ -4,19 +4,30 @@ package weaver
 class SourceLocation private (
     private[weaver] val filePath: String,
     private[weaver] val fileRelativePath: String,
-    private[weaver] val line: Int
+    private[weaver] val line: Int,
+    private[weaver] val sourceCode: Option[SourceLocation.SourceCode]
 ) {
   private[weaver] def fileName: Option[String] = filePath.split("/").lastOption
 }
 
 object SourceLocation extends SourceLocationMacro {
+
+  private[weaver] class SourceCode(
+      private[weaver] val sourceLine: String,
+      private[weaver] val column: Int
+  )
+
   def apply(
       filePath: String,
       fileRelativePath: String,
-      line: Int
+      line: Int,
+      sourceLineAndColumn: Option[(String, Int)]
   ): SourceLocation = new SourceLocation(
     filePath,
     fileRelativePath,
-    line
+    line,
+    sourceLineAndColumn.map { case (source, col) =>
+      new SourceCode(source, col)
+    }
   )
 }


### PR DESCRIPTION
This PR adds source code to all failure messages.

This includes weaver expectations such as `expect.same` and `failure`, but should also work for user-propagated source locations.

## Example
<img width="626" height="367" alt="image" src="https://github.com/user-attachments/assets/f87e8bc1-05c5-42a4-ab28-dff561411527" />

## Pointing to the failure

For Scala 2, the source position obtained from the `SourceLocationMacro` corresponds to the opening brace of the expectation. For example, the `◊` in:

```
 expect.same(◊x, y) && expect.same(y, z)
```

For Scala 3, it corresponds to the closing brace:

```
 expect.same(x, y)◊ && expect.same(y, z)
```

We use the position to point to the failing expectation:

```
expect.same(x, y) && expect.same(y, z)
           ^
```