### PR TITLE
Less discarding of test failure throwables

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/TestOutcome.scala
+++ b/modules/core/shared/src/main/scala/weaver/TestOutcome.scala
@@ -45,7 +45,11 @@ object TestOutcome {
     def cause: Option[Throwable] = result match {
       case Result.Exception(cause, _)       => Some(cause)
       case Result.Failure(_, maybeCause, _) => maybeCause
-      case _                                => None
+      case Result.Failures(failures) =>
+        failures.collectFirst {
+          case Result.Failure(_, Some(cause), _) => cause
+        }
+      case _ => None
     }
 
     def formatted(mode: Mode): String =


### PR DESCRIPTION
... and more propagating thereof.

On one end, it seems a shame to discard information that we have.

On the other end, receiver of the `sbt.testing.Event` - in my case, [Gradle plugin for multi-backend Scala](https://github.com/dubinsky/scalajs-gradle) - has to provide a throwable to Gradle, which requires one to accompany a test failure, and if it is not propagated by the test framework, a fake throwable has to be concocted (ugh).

This change makes the ends meet ;)