### PR TITLE
Build for Scala Native 0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,20 +36,20 @@ ThisBuild / crossScalaVersions := Seq(scala212, scala213, "3.3.6")
 ThisBuild / scalaVersion       := scala213 // the default Scala
 
 val Version = new {
-  val catsEffect             = "3.6.3"
-  val catsLaws               = "2.11.0"
-  val discipline             = "1.5.1"
-  val fs2                    = "3.12.0"
+  val catsEffect             = "3.7.0-RC1"
+  val catsLaws               = "2.13.0"
+  val discipline             = "1.7.0"
+  val fs2                    = "3.13.0-M6"
   val junit                  = "4.13.2"
   val portableReflect        = "1.1.3"
   val scalaJavaTime          = "2.4.0"
-  val scalacheck             = "1.17.1"
+  val scalacheck             = "1.18.1"
   val scalajsMacroTask       = "1.1.1"
   val scalajsStubs           = "1.1.0"
   val testInterface          = "1.0"
   val scalacCompatAnnotation = "0.1.4"
   val http4s                 = "0.23.26"
-  val munitDiff              = "1.0.0"
+  val munitDiff              = "1.1.0"
 }
 
 lazy val root = tlCrossRootProject.aggregate(core,
@@ -164,6 +164,7 @@ lazy val discipline = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(core, cats)
   .settings(
     name           := "weaver-discipline",
+    evictionErrorLevel := Level.Info, // scalacheck is built with native 0.5.1, which sbt dislikes
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "discipline-core" % Version.discipline,

--- a/modules/core/native/src/main/scala/weaver/internals/Timestamp.scala
+++ b/modules/core/native/src/main/scala/weaver/internals/Timestamp.scala
@@ -11,7 +11,7 @@ private[weaver] object Timestamp {
   def format(epochSecond: Long): String = {
     val out     = stackalloc[time.tm]()
     val timePtr = stackalloc[time.time_t]()
-    !timePtr = epochSecond
+    !timePtr = epochSecond.toSize
     val gmTime: Ptr[time.tm] = time.localtime_r(timePtr, out)
     val hour                 = gmTime.tm_hour
     val minutes              = gmTime.tm_min

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("ch.epfl.scala"        % "sbt-scalafix"                  % "0.14.3"
 
 addSbtPlugin("org.scala-js"         % "sbt-scalajs"                   % "1.18.2")
 
-addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.4.17")
+addSbtPlugin("org.scala-native"     % "sbt-scala-native"              % "0.5.8")
 
 addSbtPlugin("org.typelevel"        % "sbt-typelevel"                 % "0.8.0")
 


### PR DESCRIPTION
This PR builds a snapshot version of weaver for Scala Native 0.5.x series, enabling users to use [Cats Effect 3.7.0-RC1](https://github.com/typelevel/cats-effect/releases/tag/v3.7.0-RC1)