### PR TITLE
Render expected value on failure when string diff is the same.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Comparison.scala
+++ b/modules/core/shared/src/main/scala/weaver/Comparison.scala
@@ -44,9 +44,16 @@ object Comparison {
         if (eqv.eqv(found, expected)) {
           Result.Success
         } else {
-          val report =
-            Diffs.createDiffOnlyReport(showA.show(found), showA.show(expected))
-          Result.Failure(report)
+          val foundStr    = showA.show(found)
+          val expectedStr = showA.show(expected)
+          if (foundStr == expectedStr) {
+            Result.Failure(
+              s"Values have the same string representation. Consider modifying their Show instance.\n${foundStr}")
+          } else {
+            val report = Diffs.createDiffOnlyReport(showA.show(found),
+                                                    showA.show(expected))
+            Result.Failure(report)
+          }
         }
       }
     }

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -293,6 +293,24 @@ object DogFoodTests extends IOSuite {
     }
   }
 
+  test("expect.eql values with the same string representation are rendered") {
+    _.runSuite(Meta.Rendering).map {
+      case (logs, _) =>
+        val actual = extractFailureMessageForTest(logs, "(eql Show)")
+
+        val expected =
+          s"""
+        |- (eql Show) 0ms
+        |  Values not equal: (src/main/DogFoodTests.scala:5)
+        |
+        |  Values have the same string representation. Consider modifying their Show instance.
+        |  foo
+        """.stripMargin.trim
+
+        expect.same(expected, actual)
+    }
+  }
+
   test("expect statements with interpolators are rendered without warnings") {
     _.runSuite(Meta.Rendering).map {
       case (logs, _) =>

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -100,6 +100,11 @@ object Meta {
       expect.same(Foo("foo", 1), Foo("foo", 2))
     }
 
+    pureTest("(eql Show)") {
+      implicit val showForString: Show[String] = _.toLowerCase
+      expect.eql("FOO", "foo")
+    }
+
     pureTest("(interpolator)") {
       val x = 1
       // The following code should not raise a "possible missing interpolator" warning


### PR DESCRIPTION
Obtained and expected values might not be equal, but have the same string representation. We currently render:

```
Values not equal: (src/main/DogFoodTests.scala:5)
  => Diff (- obtained, + expected)
```

and don't render the string representation of the value. This PR renders:

```
Values not equal: (src/main/DogFoodTests.scala:5)

Values have the same string representation. Consider modifying their Show instance.
foo
```