### PR TITLE
Line content should be empty if expectation is on last line.

### DIFF
--- a/modules/core/shared/src/main/scala-3/weaver/SourceLocationMacro.scala
+++ b/modules/core/shared/src/main/scala-3/weaver/SourceLocationMacro.scala
@@ -27,7 +27,8 @@ object macros {
     val position = Position.ofMacroExpansion
     val lineSource = position.sourceFile.content.map { content =>
       val lineContentBefore = content.slice(0, position.end).split("\\r?\\n").last
-      val lineContentAfter = content.drop(position.end).split("\\r?\\n").head
+      // If the expect statement is the last line in the file, the line content after it will be empty
+      val lineContentAfter = content.drop(position.end).split("\\r?\\n").headOption.getOrElse("")
       val column = lineContentBefore.length
       (s"$lineContentBefore$lineContentAfter", column)
     }


### PR DESCRIPTION
The `0.10.0` source location raises a `NoSuchElementException` when the `expect` statement is on the last line in a file:

```scala
object MySuite extends FunSuite:
  test("parse and compare valid semver"):
    expect.all(
      1 > 2
    )
```

This can be reproduced with scala-cli using [this gist](https://gist.github.com/zainab-ali/c21482f3ed89d81e78e7d2c405580e2e):

```
scala-cli test https://gist.github.com/zainab-ali/c21482f3ed89d81e78e7d2c405580e2e
```

Compiling the snippet raises an error:
```
[error] Exception occurred while executing macro expansion.
[error] java.util.NoSuchElementException: head of empty array
[error]         at scala.collection.ArrayOps$.head$extension(ArrayOps.scala:233)
[error]         at weaver.macros$.$anonfun$1(SourceLocationMacro.scala:30)
[error]         at scala.Option.map(Option.scala:242)
[error]         at weaver.macros$.fromContextImpl(SourceLocationMacro.scala:28)
[error]
[error]     )
```

The head of the array of lines is empty.  The `expect` statement is on the last line, and so the line content after it is blank. This can be addressed by returning an empty string as a default.

Using the fix, the test compiles and the failure message is:
```
MySuite
- parse and compare valid semver 7ms
  assertion failed (MySuite.test.scala:11)

  1 > 2

  Use the `clue` function to troubleshoot

  MySuite.test.scala:11
      )
      ^
```

Unfortunately this is difficult to write a test for.