### PR TITLE
Add a new line between failure messages and logs.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Result.scala
+++ b/modules/core/shared/src/main/scala/weaver/Result.scala
@@ -57,7 +57,7 @@ object Result {
             )
         }
 
-        Some(descriptions.toList.mkString(DOUBLE_EOL))
+        Some(descriptions.toList.mkString("", DOUBLE_EOL, DOUBLE_EOL))
       }
   }
 

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -63,26 +63,42 @@ object DogFoodTests extends IOSuite {
   }
 
   test("test suite outputs logs for failed tests") {
-    _.runSuite(Meta.FailingSuiteWithlogs).map {
+    _.runSuite(Meta.FailingSuiteWithLogs).flatMap {
       case (logs, _) =>
-        val expected =
-          s"""
-            |- failure 0ms
-            |  expected (src/main/DogFoodTests.scala:5)
-            |
-            |    [INFO]  12:54:35 [DogFoodTests.scala:5] this test
-            |    [ERROR] 12:54:35 [DogFoodTests.scala:5] has failed
-            |    [DEBUG] 12:54:35 [DogFoodTests.scala:5] with context
-            |        a       -> b
-            |        token   -> <something>
-            |        request -> true
-            |""".stripMargin.trim
+        val actual = extractFailureMessageForTest(logs, "(failure)")
+        assertInlineSnapshot(
+          actual,
+          """- (failure) 0ms
+  expected (src/main/DogFoodTests.scala:5)
 
-        exists(extractLogEventAfterFailures(logs) {
-          case LoggedEvent.Error(msg) => msg
-        }) { actual =>
-          expect.same(expected, actual)
-        }
+    [INFO]  12:54:35 [DogFoodTests.scala:5] this test
+    [ERROR] 12:54:35 [DogFoodTests.scala:5] has failed
+    [DEBUG] 12:54:35 [DogFoodTests.scala:5] with context
+        a       -> b
+        token   -> <something>
+        request -> true"""
+        )
+    }
+  }
+
+  test("test suite renders logs for tests with multiple failures") {
+    _.runSuite(Meta.FailingSuiteWithLogs).flatMap {
+      case (logs, _) =>
+        val actual = extractFailureMessageForTest(logs, "(multiple-failures)")
+        assertInlineSnapshot(
+          actual,
+          """- (multiple-failures) 0ms
+ [0] expected (src/main/DogFoodTests.scala:5)
+
+ [1] another (src/main/DogFoodTests.scala:5)
+
+    [INFO]  12:54:35 [DogFoodTests.scala:5] this test
+    [ERROR] 12:54:35 [DogFoodTests.scala:5] has failed
+    [DEBUG] 12:54:35 [DogFoodTests.scala:5] with context
+        a       -> b
+        token   -> <something>
+        request -> true"""
+        )
     }
   }
 

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -195,12 +195,12 @@ object Meta {
     }
   }
 
-  object FailingSuiteWithlogs extends SimpleIOSuite {
+  object FailingSuiteWithLogs extends SimpleIOSuite {
     override implicit protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
-    loggedTest("failure") { log =>
+    loggedTest("(failure)") { log =>
       val context = Map(
         "a"       -> "b",
         "token"   -> "<something>",
@@ -214,6 +214,19 @@ object Meta {
       } yield failure("expected")
     }
 
+    loggedTest("(multiple-failures)") { log =>
+      val context = Map(
+        "a"       -> "b",
+        "token"   -> "<something>",
+        "request" -> "true"
+      )
+
+      for {
+        _ <- log.info("this test")
+        _ <- log.error("has failed")
+        _ <- log.debug("with context", context)
+      } yield failure("expected") && failure("another")
+    }
   }
 
   object ErroringWithCauses extends SimpleIOSuite {


### PR DESCRIPTION
There is no newline between failure messages and log messages if there are multiple failures.

For example, if we adjust the test in `logging.md` slightly, we see:

<img width="633" height="628" alt="Screenshot 2025-09-03 at 12 35 52" src="https://github.com/user-attachments/assets/18762d5a-6ab7-4fb3-8e83-a1d708aff013" />

This is resolved by adding a `DOUBLE_EOL` to the formatted message for multiple failures.
