### PR TITLE
Move DogFoodTests to snapshot tests

### DIFF
--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -263,7 +263,7 @@ object Meta {
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
-    loggedTest("failure") { log =>
+    loggedTest("(failure)") { log =>
       for {
         _ <- log.error(
           "error",


### PR DESCRIPTION
This PR refactors all relevant `DogFoodTests` to snapshot tests.

The only change aside from refactoring is the rename of a test from `failure` to `(failure)` to align with other test naming conventions.