### PR TITLE
DisciplineFSuite should respect test tags.

### DIFF
--- a/modules/discipline/shared/src/test/scala/DisciplineFSuiteIntegrationTest.scala
+++ b/modules/discipline/shared/src/test/scala/DisciplineFSuiteIntegrationTest.scala
@@ -51,6 +51,12 @@ object DisciplineFSuiteIntegrationTest extends SimpleIOSuite {
     }
   }
 
+  test("Respects ignored tests") {
+    MetaIgnore.spec(Nil).compile.toList.map { outcomes =>
+      expect.eql(outcomes.map(_.name).toSet, Set.empty[String])
+    }
+  }
+
   object MetaSuccess extends DisciplineFSuite[IO] with BaseIOSuite {
     override type Res = String
     override def sharedResource: Resource[IO, String] =
@@ -82,6 +88,14 @@ object DisciplineFSuiteIntegrationTest extends SimpleIOSuite {
       Resource.eval(IO.raiseError(resourceStart))
 
     checkAll("Int").pure(_ => RickrollTests[Int].all)
+  }
+
+  object MetaIgnore extends DisciplineFSuite[IO] with BaseIOSuite {
+    override type Res = String
+    override def sharedResource: Resource[IO, String] =
+      Resource.pure("resource")
+
+    checkAll("Boolean".ignore).pure(_ => RickrollTests[Boolean].all)
   }
 
 }

--- a/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
+++ b/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
@@ -108,8 +108,8 @@ object JUnitRunnerTests extends SimpleIOSuite {
       val expected = List(
         TestSuiteStarted("weaver.junit.Meta$IgnoreAndOnly$"),
         TestIgnored("only and ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
-        TestIgnored("is ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
         TestIgnored("not tagged(weaver.junit.Meta$IgnoreAndOnly$)"),
+        TestIgnored("is ignored(weaver.junit.Meta$IgnoreAndOnly$)"),
         TestStarted("only(weaver.junit.Meta$IgnoreAndOnly$)"),
         TestFinished("only(weaver.junit.Meta$IgnoreAndOnly$)"),
         TestSuiteFinished("weaver.junit.Meta$IgnoreAndOnly$")
@@ -181,8 +181,6 @@ object JUnitRunnerTests extends SimpleIOSuite {
 
       val expected = List(
         TestSuiteStarted("weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$"),
-        TestIgnored(
-          "only and ignored(weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$)"),
         TestStarted(
           "only and ignored(weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$)"),
         testFailure,
@@ -190,7 +188,7 @@ object JUnitRunnerTests extends SimpleIOSuite {
           "only and ignored(weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$)"),
         TestSuiteFinished("weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$")
       )
-      expect.eql(expected, notifications)
+      expect.eql(notifications, expected)
     }
   }
 


### PR DESCRIPTION
This PR addresses #210 

## Using `DisciplineFSuite` with `IOSuite`
Users could previously use `DisciplineFSuite` with `IOSuite`, however their tests defined with `test(...)` would not be run.

The `DisciplineFSuite` is now abstract. Users cannot mix it in to `IOSuite`, so cannot create these tests. 

## Using `.only` and `.ignore`
This needed a bunch of refactors to the `analyze` and `spec` functions, which lead to refactors in the JUnit runner.

- `analyze` now outputs a datatype containing all tests present in the `plan`. It includes ignored tests, outcomes, and tests to be run.
- The logic for determining ignored tests was duplicated between the `WeaverRunner` and the `RunnableSuite.analyze` method. The `WeaverRunner` logic has been removed to use the results of `analyze`.
- Instead of overriding `spec`, suites override `eval`. This is passed a list of test names that have already been filtered.
- The `spec` function is now `final` and filters tests using `analyze`, then passes the filtered tests to the custom `eval` function.

## Remaining work

I have yet to test this properly with IntelliJ. The `eval` function could also use a better name.