### PR TITLE
Fix bug in `--only` argument detection.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Filters.scala
+++ b/modules/core/shared/src/main/scala/weaver/Filters.scala
@@ -47,10 +47,10 @@ private[weaver] object Filters {
     }
 
     import scala.util.Try
+    def indexOfOption(opt: String): Option[Int] =
+      Option(args.indexOf(opt)).filter(_ >= 0)
     val maybePattern = for {
-      index <- Option(args.indexOf("-o"))
-        .orElse(Option(args.indexOf("--only")))
-        .filter(_ >= 0)
+      index  <- indexOfOption("-o").orElse(indexOfOption("--only"))
       filter <- Try(args(index + 1)).toOption
     } yield toPredicate(filter)
     testId => maybePattern.forall(_.apply(testId))

--- a/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
@@ -53,9 +53,21 @@ object TagDogFoodTests extends IOSuite {
     }
   }
 
-  test("test runner arguments should be respected if no tests are tagged with 'only'") {
+  test("test runner -o argument should be respected if no tests are tagged with 'only'") {
     _.runSuite(Meta.TestRunnerArgs,
                Array("-o", "*matches-args*")).flatMap {
+      case (logs, _) =>
+        assertInlineSnapshot(
+          infoMessages(logs),
+          List("weaver.framework.test.TagDogFoodTests$Meta$TestRunnerArgs",
+               "+ (matches-args) 0ms")
+        )
+    }
+  }
+
+  test("test runner --only argument should be respected if no tests are tagged with 'only'") {
+    _.runSuite(Meta.TestRunnerArgs,
+               Array("--only", "*matches-args*")).flatMap {
       case (logs, _) =>
         assertInlineSnapshot(
           infoMessages(logs),


### PR DESCRIPTION
The following command doesn't respect the filter passed to `--only`.

```
sbt testOnly MySuite -- --only *filter*
```

This is due to a bug in the `Filters` logic. `args.indexOf("-o")` returns `-1`, so is always non-empty, and `args.indexOf("--only")` is not executed.