### PR TITLE
Create matchOrFailFast utility

### DIFF
--- a/docs/features/expectations.md
+++ b/docs/features/expectations.md
@@ -112,6 +112,18 @@ val list = List(1)
   } yield expect(y.contains(x))
   ```
 
+- Similarly `matchOrFailFast` can be used assert an expression matches a given pattern, and return it if so
+
+  ```scala mdoc:compile-only
+  for {
+    b <- IO(Some(4))
+    s <- matchOrFailFast[IO](b) {
+      case Some(v) => v.toString    
+    }
+    c <- IO("4")
+  } yield expect.eql(s, c)
+  ```
+
 ## Example suite 
 
 ```scala mdoc
@@ -220,6 +232,19 @@ object ExpectationsSuite extends SimpleIOSuite {
       h <- IO.pure("hello")
       _ <- expect(clue(h).isEmpty).failFast
     } yield success
+  }
+
+  test("Failing fast match") {
+    for {
+      h <- IO.pure(Some(4))
+      x <- matchOrFailFast[IO](h) {
+        case Some(v) => v
+      }
+      g <- IO.pure(Option.empty[Int])
+      y <- matchOrFailFast[IO](g) {
+        case Some(v) => v
+      }
+    } yield expect.eql(x, y)
   }
 }
 ```

--- a/modules/framework-cats/shared/src/test/scala/ExpectationsTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/ExpectationsTests.scala
@@ -2,6 +2,7 @@ package weaver
 package framework
 package test
 
+import cats.effect.IO
 import cats.kernel.Eq
 
 object ExpectationsTests extends SimpleIOSuite {
@@ -59,6 +60,24 @@ object ExpectationsTests extends SimpleIOSuite {
       not(matches(Option(4)) { case None =>
         failure("dead code")
       })
+  }
+
+  test("matchOrFailFast (success)") {
+    matchOrFailFast[IO](Some(4)) {
+      case Some(v) => v
+    }.as(success)
+  }
+
+  test("matchOrFailFast (failure)") {
+    matchOrFailFast[IO](Option.empty[Int]) {
+      case Some(v) => v
+    }
+      .attempt
+      .map { either =>
+        matches(either) { case Left(_: ExpectationFailed) =>
+          success
+        }
+      }
   }
 
   pureTest("expect.eql respects cats.kernel.Eq") {


### PR DESCRIPTION
Hi, I've found that a utility that accomplishes what `matches` does, but returns the match instead of an `Expectation` is helpful sometimes, avoiding situations like:

```scala
for {
  _ <- expect.eql(myVar, someForm).failFast
  myVarInForm <- unsafeGet(myVar)
 // Further logic + assertions ...
} yield ()
```

The idea is the above can be replaced by `matchOrFailFast` which performs both steps at the same time.

I wasn't really sure the best place to put tests, but LMK what you think about that and the feature.

Thanks!