### PR TITLE
Update Scala Native, Cats Effect, fs2 & related deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val Version = new {
   val snapshot4s             = _root_.snapshot4s.BuildInfo.snapshot4sVersion
 }
 
-// Scala native doesn't publish version scheme so we have to explicitly define it
+// Scala native test-interface version scheme is set to strict, so we have to explicitly overrule it
 ThisBuild / libraryDependencySchemes += "org.scala-native" %% "test-interface_native0.5" % "early-semver"
 
 // Scala Native 0.5 support starts with 0.11.4, so skip MiMa checks for native artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -47,13 +47,13 @@ val Version = new {
   val junit                  = "4.13.2"
   val portableReflect        = "1.1.3"
   val scalaJavaTime          = "2.4.0"
-  val scalacheck             = "1.17.1"
+  val scalacheck             = "1.19.0"
   val scalajsMacroTask       = "1.1.1"
   val scalajsStubs           = "1.1.0"
   val testInterface          = "1.0"
   val scalacCompatAnnotation = "0.1.4"
   val http4s                 = "0.23.26"
-  val munitDiff              = "1.0.0"
+  val munitDiff              = "1.2.4"
   val snapshot4s             = _root_.snapshot4s.BuildInfo.snapshot4sVersion
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,8 @@ val Version = new {
 }
 
 // Scala native test-interface version scheme is set to strict, so we have to explicitly overrule it
-ThisBuild / libraryDependencySchemes += "org.scala-native" %% "test-interface_native0.5" % "early-semver"
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-native" %% "test-interface_native0.5" % "early-semver"
 
 // Scala Native 0.5 support starts with 0.11.4, so skip MiMa checks for native artifacts
 lazy val nativeMimaSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,9 @@ val Version = new {
   val snapshot4s             = _root_.snapshot4s.BuildInfo.snapshot4sVersion
 }
 
+// Scala native doesn't publish version scheme so we have to explicitly define it
+ThisBuild / libraryDependencySchemes += "org.scala-native" %% "test-interface_native0.5" % "early-semver"
+
 lazy val root = tlCrossRootProject.aggregate(core,
                                              framework,
                                              coreCats,

--- a/build.sbt
+++ b/build.sbt
@@ -40,10 +40,10 @@ ThisBuild / crossScalaVersions := Seq(scala212, scala213, "3.3.7")
 ThisBuild / scalaVersion       := scala213 // the default Scala
 
 val Version = new {
-  val catsEffect             = "3.6.3"
-  val catsLaws               = "2.11.0"
-  val discipline             = "1.5.1"
-  val fs2                    = "3.12.2"
+  val catsEffect             = "3.7.0"
+  val catsLaws               = "2.13.0"
+  val discipline             = "1.7.0"
+  val fs2                    = "3.13.0"
   val junit                  = "4.13.2"
   val portableReflect        = "1.1.3"
   val scalaJavaTime          = "2.4.0"

--- a/build.sbt
+++ b/build.sbt
@@ -61,11 +61,6 @@ val Version = new {
 ThisBuild / libraryDependencySchemes +=
   "org.scala-native" %% "test-interface_native0.5" % "early-semver"
 
-// Scala Native 0.5 support starts with 0.11.4, so skip MiMa checks for native artifacts
-lazy val nativeMimaSettings = Seq(
-  tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.11.4").toMap
-)
-
 lazy val root = tlCrossRootProject.aggregate(core,
                                              framework,
                                              coreCats,
@@ -74,7 +69,6 @@ lazy val root = tlCrossRootProject.aggregate(core,
                                              discipline)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .nativeSettings(nativeMimaSettings)
   .in(file("modules/core"))
   .settings(
     name := "weaver-core",
@@ -121,7 +115,6 @@ lazy val coreJS =
 
 lazy val framework = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/framework"))
-  .nativeSettings(nativeMimaSettings)
   .dependsOn(core)
   .settings(
     name := "weaver-framework",
@@ -158,7 +151,6 @@ lazy val frameworkNative = framework.native
 lazy val coreCats = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/core-cats"))
   .dependsOn(core)
-  .nativeSettings(nativeMimaSettings)
   .settings(
     libraryDependencies ++= Seq(
       "junit" % "junit" % Version.junit % ScalaDocTool
@@ -176,7 +168,6 @@ lazy val coreCatsJS = coreCats.js
 lazy val cats = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/framework-cats"))
   .dependsOn(framework, coreCats)
-  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-cats",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect"))
@@ -191,7 +182,6 @@ lazy val catsJVM = cats.jvm
 lazy val scalacheck = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/scalacheck"))
   .dependsOn(core, cats % "test->compile")
-  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-scalacheck",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
@@ -203,7 +193,6 @@ lazy val scalacheck = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 lazy val discipline = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/discipline"))
   .dependsOn(core, cats)
-  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-discipline",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,11 @@ val Version = new {
 // Scala native doesn't publish version scheme so we have to explicitly define it
 ThisBuild / libraryDependencySchemes += "org.scala-native" %% "test-interface_native0.5" % "early-semver"
 
+// Scala Native 0.5 support starts with 0.11.4, so skip MiMa checks for native artifacts
+lazy val nativeMimaSettings = Seq(
+  tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.11.4").toMap
+)
+
 lazy val root = tlCrossRootProject.aggregate(core,
                                              framework,
                                              coreCats,
@@ -68,6 +73,7 @@ lazy val root = tlCrossRootProject.aggregate(core,
                                              discipline)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .nativeSettings(nativeMimaSettings)
   .in(file("modules/core"))
   .settings(
     name := "weaver-core",
@@ -114,6 +120,7 @@ lazy val coreJS =
 
 lazy val framework = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/framework"))
+  .nativeSettings(nativeMimaSettings)
   .dependsOn(core)
   .settings(
     name := "weaver-framework",
@@ -150,6 +157,7 @@ lazy val frameworkNative = framework.native
 lazy val coreCats = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/core-cats"))
   .dependsOn(core)
+  .nativeSettings(nativeMimaSettings)
   .settings(
     libraryDependencies ++= Seq(
       "junit" % "junit" % Version.junit % ScalaDocTool
@@ -167,6 +175,7 @@ lazy val coreCatsJS = coreCats.js
 lazy val cats = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/framework-cats"))
   .dependsOn(framework, coreCats)
+  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-cats",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect"))
@@ -181,6 +190,7 @@ lazy val catsJVM = cats.jvm
 lazy val scalacheck = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/scalacheck"))
   .dependsOn(core, cats % "test->compile")
+  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-scalacheck",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),
@@ -192,6 +202,7 @@ lazy val scalacheck = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 lazy val discipline = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("modules/discipline"))
   .dependsOn(core, cats)
+  .nativeSettings(nativeMimaSettings)
   .settings(
     name           := "weaver-discipline",
     testFrameworks := Seq(new TestFramework("weaver.framework.CatsEffect")),

--- a/modules/core-cats/native/src/main/scala/weaver/CatsUnsafeRunPlatformCompat.scala
+++ b/modules/core-cats/native/src/main/scala/weaver/CatsUnsafeRunPlatformCompat.scala
@@ -11,7 +11,7 @@ private[weaver] trait CatsUnsafeRunPlatformCompat {
 
   def unsafeRunSync(task: IO[Unit]): Unit = {
     val future = task.unsafeToFuture()
-    scalanative.runtime.loop()
+    scala.scalanative.LoopCompat.helpComplete()
     Await.result(future, 1.minute)
   }
 

--- a/modules/core/native/src/main/scala/scala/scalanative/LoopCompat.scala
+++ b/modules/core/native/src/main/scala/scala/scalanative/LoopCompat.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 
 // Exposes the package-private replacement for the deprecated scalanative.runtime.loop().
 // Must live in package scala.scalanative to access NativeExecutionContext.queueInternal which is private[scalanative]
-// as suggested by deprecation warning
+// as suggested by deprecation warning: https://github.com/scala-native/scala-native/blob/d696e695268146edce1a96e51188218a31cc782e/nativelib/src/main/scala/scala/scalanative/runtime/package.scala#L169
 object LoopCompat {
   def helpComplete(): Unit =
     concurrent.NativeExecutionContext.queueInternal.helpComplete()

--- a/modules/core/native/src/main/scala/scala/scalanative/LoopCompat.scala
+++ b/modules/core/native/src/main/scala/scala/scalanative/LoopCompat.scala
@@ -1,0 +1,9 @@
+package scala.scalanative
+
+// Exposes the package-private replacement for the deprecated scalanative.runtime.loop().
+// Must live in package scala.scalanative to access NativeExecutionContext.queueInternal which is private[scalanative]
+// as suggested by deprecation warning
+object LoopCompat {
+  def helpComplete(): Unit =
+    concurrent.NativeExecutionContext.queueInternal.helpComplete()
+}

--- a/modules/core/native/src/main/scala/weaver/internals/Timestamp.scala
+++ b/modules/core/native/src/main/scala/weaver/internals/Timestamp.scala
@@ -11,7 +11,7 @@ private[weaver] object Timestamp {
   def format(epochSecond: Long): String = {
     val out     = stackalloc[time.tm]()
     val timePtr = stackalloc[time.time_t]()
-    !timePtr = epochSecond
+    !timePtr = epochSecond.toSize
     val gmTime: Ptr[time.tm] = time.localtime_r(timePtr, out)
     val hour                 = gmTime.tm_hour
     val minutes              = gmTime.tm_min

--- a/modules/core/shared/src/main/scala/weaver/Comparison.scala
+++ b/modules/core/shared/src/main/scala/weaver/Comparison.scala
@@ -58,7 +58,7 @@ object Comparison {
             // Newer versions of munit-diff (1.1.0+) will reverse the order of `expected` and `found` arguments.
             // When we upgrade to munit-diff `1.1.0`, we should switch the order to `found` then `expected`.
             val report =
-              Diff.unifiedDiff(showA.show(expected), showA.show(found))
+              Diff.unifiedDiff(showA.show(found), showA.show(expected))
             Result.Failure(header + "\n" + report)
           }
         }

--- a/modules/core/shared/src/main/scala/weaver/Comparison.scala
+++ b/modules/core/shared/src/main/scala/weaver/Comparison.scala
@@ -3,7 +3,7 @@ package weaver
 import cats.Eq
 import cats.Show
 import scala.annotation.implicitNotFound
-import munit.diff.Diffs
+import munit.diff.Diff
 import munit.diff.console.AnsiColors
 import weaver.internals.MultiLineShow
 
@@ -58,7 +58,7 @@ object Comparison {
             // Newer versions of munit-diff (1.1.0+) will reverse the order of `expected` and `found` arguments.
             // When we upgrade to munit-diff `1.1.0`, we should switch the order to `found` then `expected`.
             val report =
-              Diffs.unifiedDiff(showA.show(expected), showA.show(found))
+              Diff.unifiedDiff(showA.show(expected), showA.show(found))
             Result.Failure(header + "\n" + report)
           }
         }

--- a/modules/core/shared/src/main/scala/weaver/Comparison.scala
+++ b/modules/core/shared/src/main/scala/weaver/Comparison.scala
@@ -55,9 +55,7 @@ object Comparison {
             val expectedHeader = AnsiColors.c("- expected", AnsiColors.LightRed)
             val foundHeader    = AnsiColors.c("+ found", AnsiColors.LightGreen)
             val header         = s"($expectedHeader, $foundHeader)"
-            // Newer versions of munit-diff (1.1.0+) will reverse the order of `expected` and `found` arguments.
-            // When we upgrade to munit-diff `1.1.0`, we should switch the order to `found` then `expected`.
-            val report =
+            val report         =
               Diff.unifiedDiff(showA.show(found), showA.show(expected))
             Result.Failure(header + "\n" + report)
           }

--- a/modules/framework/native/src/main/scala/PlatformTask.scala
+++ b/modules/framework/native/src/main/scala/PlatformTask.scala
@@ -11,7 +11,7 @@ private[weaver] trait PlatformTask extends AsyncTask {
       eventHandler: EventHandler,
       loggers: Array[Logger]): Array[Task] = {
     val future = executeFuture(eventHandler, loggers)
-    scalanative.runtime.loop()
+    scala.scalanative.LoopCompat.helpComplete()
     Await.result(future, 5.minutes)
     Array.empty[Task]
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.2")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.10")
 
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.8.5")
 


### PR DESCRIPTION
https://github.com/typelevel/weaver-test/tree/feature/native-0.5 is far behind main and difficult to rebase. This PR bumps Scala Native again, based on recent stable releases of Cats Effect and fs2