### PR TITLE
Remove unused `unsafeRunAndForget` function.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import laika.config.LinkValidation
 import org.typelevel.sbt.site.TypelevelSiteSettings
 import sbt.librarymanagement.Configurations.ScalaDocTool
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.12" // your current series x.y
+ThisBuild / tlBaseVersion := "0.13" // your current series x.y
 
 ThisBuild / startYear  := Some(2019)
 ThisBuild / licenses   := Seq(License.Apache2)

--- a/modules/core-cats/native/src/main/scala/weaver/CatsUnsafeRunPlatformCompat.scala
+++ b/modules/core-cats/native/src/main/scala/weaver/CatsUnsafeRunPlatformCompat.scala
@@ -1,19 +1,11 @@
 package weaver
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 
 private[weaver] trait CatsUnsafeRunPlatformCompat {
   self: CatsUnsafeRun =>
 
-  def unsafeRunSync(task: IO[Unit]): Unit = {
-    val future = task.unsafeToFuture()
-    scala.scalanative.LoopCompat.helpComplete()
-    Await.result(future, 1.minute)
-  }
+  def unsafeRunSync(task: IO[Unit]): Unit = ???
 
   def background(task: IO[Unit]): CancelToken = ???
 

--- a/modules/core-cats/shared/src/main/scala/weaver/CatsUnsafeRun.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/CatsUnsafeRun.scala
@@ -16,7 +16,6 @@ trait CatsUnsafeRun extends UnsafeRun[IO] with CatsUnsafeRunPlatformCompat {
 
   def cancel(token: CancelToken): Unit = unsafeRunSync(token.cancel)
 
-  def unsafeRunAndForget(task: IO[Unit]): Unit = task.unsafeRunAndForget()
   def unsafeRunToFuture(task: IO[Unit]): Future[Unit] = task.unsafeToFuture()
 
 }

--- a/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
+++ b/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
@@ -32,7 +32,6 @@ trait UnsafeRun[F[_]] extends EffectCompat[F] {
   def cancel(token: CancelToken): Unit
 
   def unsafeRunSync(task: F[Unit]): Unit
-  def unsafeRunAndForget(task: F[Unit]): Unit
   def unsafeRunToFuture(task: F[Unit]): Future[Unit]
 
 }


### PR DESCRIPTION
The `unsafeRunAndForget` function is unused within the codebase.

There's also an `unsafeRunSync` implementation for native which is unused - this function is only used by the jvm-only JUnit runner.