### PR TITLE
Remove `EffectCompat` from `Test` signature.

### DIFF
--- a/modules/core-cats/shared/src/main/scala/weaver/BaseIOSuite.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/BaseIOSuite.scala
@@ -3,5 +3,5 @@ package weaver
 import cats.effect.IO
 
 trait BaseIOSuite extends RunnableSuite[IO] with BaseCatsSuite {
-  implicit protected def effectCompat: UnsafeRun[IO] = CatsUnsafeRun
+  protected def effectCompat: UnsafeRun[IO] = CatsUnsafeRun
 }

--- a/modules/core/shared/src/main/scala/weaver/Test.scala
+++ b/modules/core/shared/src/main/scala/weaver/Test.scala
@@ -7,25 +7,25 @@ import cats.Defer
 import cats.data.Chain
 import cats.effect.Ref
 import cats.effect.Clock
+import cats.effect.Concurrent
 import cats.syntax.all._
 
 object Test {
 
   def apply[F[_]](name: String, f: Log[F] => F[Expectations])(
-      implicit F: EffectCompat[F],
-      C: Clock[F]
-  ): F[TestOutcome] = {
-    import F.effect
+      implicit F: Defer[F],
+      G: Concurrent[F],
+      C: Clock[F]): F[TestOutcome] = {
     for {
       ref   <- Ref[F].of(Chain.empty[Log.Entry])
-      start <- C.realTime.map(_.toMillis)
+      start <- C.realTime
       res   <- Defer[F]
         .defer(f(Log.collected[F, Chain](ref, C.realTime.map(_.toMillis))))
         .map(Result.fromAssertion)
         .handleError(ex => Result.from(ex))
-      end  <- C.realTime.map(_.toMillis)
+      end  <- C.realTime
       logs <- ref.get
-    } yield TestOutcome(name, (end - start).millis, res, logs)
+    } yield TestOutcome(name, end - start, res, logs)
   }
 
   def pure(name: String)(ex: () => Expectations): TestOutcome = {
@@ -41,7 +41,8 @@ object Test {
   }
 
   def apply[F[_]](name: String, f: F[Expectations])(
-      implicit F: EffectCompat[F],
+      implicit F: Defer[F],
+      G: Concurrent[F],
       C: Clock[F]
   ): F[TestOutcome] = apply[F](name, (_: Log[F]) => f)
 

--- a/modules/core/shared/src/main/scala/weaver/Test.scala
+++ b/modules/core/shared/src/main/scala/weaver/Test.scala
@@ -6,22 +6,24 @@ import scala.util.{ Failure, Success, Try }
 import cats.Defer
 import cats.data.Chain
 import cats.effect.Ref
+import cats.effect.Clock
 import cats.syntax.all._
 
 object Test {
 
   def apply[F[_]](name: String, f: Log[F] => F[Expectations])(
-      implicit F: EffectCompat[F]
+      implicit F: EffectCompat[F],
+      C: Clock[F]
   ): F[TestOutcome] = {
     import F.effect
     for {
       ref   <- Ref[F].of(Chain.empty[Log.Entry])
-      start <- F.realTimeMillis
+      start <- C.realTime.map(_.toMillis)
       res   <- Defer[F]
-        .defer(f(Log.collected[F, Chain](ref, F.realTimeMillis)))
+        .defer(f(Log.collected[F, Chain](ref, C.realTime.map(_.toMillis))))
         .map(Result.fromAssertion)
         .handleError(ex => Result.from(ex))
-      end  <- F.realTimeMillis
+      end  <- C.realTime.map(_.toMillis)
       logs <- ref.get
     } yield TestOutcome(name, (end - start).millis, res, logs)
   }
@@ -39,7 +41,8 @@ object Test {
   }
 
   def apply[F[_]](name: String, f: F[Expectations])(
-      implicit F: EffectCompat[F]
+      implicit F: EffectCompat[F],
+      C: Clock[F]
   ): F[TestOutcome] = apply[F](name, (_: Log[F]) => f)
 
 }

--- a/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
+++ b/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
@@ -11,10 +11,13 @@ trait EffectCompat[F[_]] {
   implicit def effect: Async[F]
   protected[weaver] def clock: Clock[F] = effect
 
-  def sleep(duration: FiniteDuration): F[Unit] = effect.sleep(duration)
-  def fromFuture[A](thunk: => scala.concurrent.Future[A]): F[A] =
+  private[weaver] final def sleep(duration: FiniteDuration): F[Unit] =
+    effect.sleep(duration)
+  private[weaver] final def fromFuture[A](
+      thunk: => scala.concurrent.Future[A]): F[A] =
     effect.fromFuture(effect.delay(thunk))
-  def async[A](cb: (Either[Throwable, A] => Unit) => Unit): F[A] =
+  private[weaver] final def async[A](cb: (Either[Throwable,
+                                                 A] => Unit) => Unit): F[A] =
     effect.async_(cb)
 }
 

--- a/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
+++ b/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
@@ -4,13 +4,13 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 import cats.Parallel
-import cats.effect.{ Async }
-import cats.syntax.all._
+import cats.effect.{ Async, Clock }
 
 trait EffectCompat[F[_]] {
   implicit def parallel: Parallel[F]
   implicit def effect: Async[F]
-  def realTimeMillis: F[Long]                  = effect.realTime.map(_.toMillis)
+  protected[weaver] def clock: Clock[F] = effect
+
   def sleep(duration: FiniteDuration): F[Unit] = effect.sleep(duration)
   def fromFuture[A](thunk: => scala.concurrent.Future[A]): F[A] =
     effect.fromFuture(effect.delay(thunk))

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -183,19 +183,25 @@ abstract class SharedResourceSuite[F[_]] extends RunnableSuite[F]
 }
 abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
-    registerTest(name)(_ => Test(name.name, effect.delay(run)))
+    registerTest(name)(_ =>
+      Test(name.name, effect.delay(run))(effectCompat, effectCompat.clock))
   def loggedTest(name: TestName)(run: Log[F] => F[Expectations]): Unit =
-    registerTest(name)(_ => Test[F](name.name, log => run(log)))
+    registerTest(name)(_ =>
+      Test[F](name.name, log => run(log))(effectCompat, effectCompat.clock))
   def test(name: TestName): PartiallyAppliedTest =
     new PartiallyAppliedTest(name)
 
   class PartiallyAppliedTest(name: TestName) {
     def apply(run: => F[Expectations]): Unit =
-      registerTest(name)(_ => Test(name.name, run))
+      registerTest(name)(_ =>
+        Test(name.name, run)(effectCompat, effectCompat.clock))
     def apply(run: Res => F[Expectations]): Unit =
-      registerTest(name)(res => Test(name.name, run(res)))
+      registerTest(name)(res =>
+        Test(name.name, run(res))(effectCompat, effectCompat.clock))
     def apply(run: (Res, Log[F]) => F[Expectations]): Unit =
-      registerTest(name)(res => Test[F](name.name, log => run(res, log)))
+      registerTest(name)(res =>
+        Test[F](name.name, log => run(res, log))(effectCompat,
+                                                 effectCompat.clock))
 
     // this alias helps using pattern matching on `Res`
     def usingRes(run: Res => F[Expectations]): Unit = apply(run)

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -23,7 +23,7 @@ trait EffectSuite[F[_]] extends BaseSuiteClass with EffectSuiteAux
     with SourceLocation.Here { self =>
 
   final type EffectType[A] = F[A]
-  implicit protected def effectCompat: EffectCompat[F]
+  protected def effectCompat: EffectCompat[F]
   implicit final protected def effect: Async[F] = effectCompat.effect
 
   def name: String = self.getClass.getName.replace("$", "")
@@ -36,7 +36,7 @@ trait EffectSuite[F[_]] extends BaseSuiteClass with EffectSuiteAux
 
 @RunWith(classOf[weaver.junit.WeaverRunner])
 abstract class RunnableSuite[F[_]] extends EffectSuite[F] {
-  implicit protected def effectCompat: UnsafeRun[EffectType]
+  protected def effectCompat: UnsafeRun[EffectType]
   private[weaver] def getEffectCompat: UnsafeRun[EffectType] = effectCompat
   private[weaver] def plan: WeaverRunnerPlan
   private[weaver] def runUnsafe(
@@ -184,23 +184,24 @@ abstract class SharedResourceSuite[F[_]] extends RunnableSuite[F]
 abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
     registerTest(name)(_ =>
-      Test(name.name, effect.delay(run))(effectCompat, effectCompat.clock))
+      Test(name.name, effect.delay(run))(effect, effect, effectCompat.clock))
   def loggedTest(name: TestName)(run: Log[F] => F[Expectations]): Unit =
     registerTest(name)(_ =>
-      Test[F](name.name, log => run(log))(effectCompat, effectCompat.clock))
+      Test[F](name.name, log => run(log))(effect, effect, effectCompat.clock))
   def test(name: TestName): PartiallyAppliedTest =
     new PartiallyAppliedTest(name)
 
   class PartiallyAppliedTest(name: TestName) {
     def apply(run: => F[Expectations]): Unit =
       registerTest(name)(_ =>
-        Test(name.name, run)(effectCompat, effectCompat.clock))
+        Test(name.name, run)(effect, effect, effectCompat.clock))
     def apply(run: Res => F[Expectations]): Unit =
       registerTest(name)(res =>
-        Test(name.name, run(res))(effectCompat, effectCompat.clock))
+        Test(name.name, run(res))(effect, effect, effectCompat.clock))
     def apply(run: (Res, Log[F]) => F[Expectations]): Unit =
       registerTest(name)(res =>
-        Test[F](name.name, log => run(res, log))(effectCompat,
+        Test[F](name.name, log => run(res, log))(effect,
+                                                 effect,
                                                  effectCompat.clock))
 
     // this alias helps using pattern matching on `Res`

--- a/modules/framework-cats/jvm/src/test/scala/MetaJVM.scala
+++ b/modules/framework-cats/jvm/src/test/scala/MetaJVM.scala
@@ -43,10 +43,6 @@ object MetaJVM {
     }
   }
 
-  object SetTimeUnsafeRun extends CatsUnsafeRun {
-    override def realTimeMillis: IO[Long] = IO.pure(0L)
-  }
-
   class LazyState(
       initialised: IO[Int],
       finalised: IO[Int],

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -13,7 +13,7 @@ object Meta {
 
   object SourceLocationSuite extends SimpleIOSuite {
 
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
 
     pureTest("(expect-same)") {
@@ -55,7 +55,7 @@ object Meta {
   }
 
   object Rendering extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
@@ -125,7 +125,7 @@ object Meta {
   }
 
   object Clue extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
@@ -189,7 +189,7 @@ object Meta {
   }
 
   object FailingTestStatusReporting extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
@@ -207,7 +207,7 @@ object Meta {
   }
 
   object FailingSuiteWithLogs extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
@@ -241,7 +241,7 @@ object Meta {
   }
 
   object ErroringWithCauses extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
 
     loggedTest("erroring with causes") { _ =>
@@ -254,7 +254,7 @@ object Meta {
   }
 
   object ErroringWithLongPayload extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
 
     val smiles = ":)" * 1024
@@ -270,7 +270,7 @@ object Meta {
   }
 
   object SucceedsWithErrorInLogs extends SimpleIOSuite {
-    override implicit protected def effectCompat: UnsafeRun[IO] =
+    override protected def effectCompat: UnsafeRun[IO] =
       SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -329,9 +329,15 @@ object Meta {
   }
 
   object SetTimeUnsafeRun extends CatsUnsafeRun {
+    import scala.concurrent.duration._
+
     private val setTimestamp = weaver.internals.Timestamp.localTime(12, 54, 35)
 
-    override def realTimeMillis: IO[Long] = IO.pure(setTimestamp)
+    override def clock: Clock[IO] = new Clock[IO] {
+      def realTime: cats.effect.IO[FiniteDuration]  = IO(setTimestamp.millis)
+      def monotonic: cats.effect.IO[FiniteDuration] = IO(0L.millis)
+      def applicative: cats.Applicative[cats.effect.IO] = cats.Applicative[IO]
+    }
   }
 
 }

--- a/modules/framework-cats/shared/src/test/scala/MutableSuiteTest.scala
+++ b/modules/framework-cats/shared/src/test/scala/MutableSuiteTest.scala
@@ -12,9 +12,9 @@ abstract class MutableSuiteTest extends SimpleIOSuite {
 
   test("sleeping") {
     for {
-      before <- CatsUnsafeRun.realTimeMillis
+      before <- CatsUnsafeRun.clock.realTime.map(_.toMillis)
       _      <- CatsUnsafeRun.sleep(1.seconds)
-      after  <- CatsUnsafeRun.realTimeMillis
+      after  <- CatsUnsafeRun.clock.realTime.map(_.toMillis)
     } yield expect(after - before >= 1000)
   }
 

--- a/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
@@ -124,7 +124,7 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object Only extends SimpleIOSuite {
-      override implicit protected def effectCompat: UnsafeRun[IO] =
+      override protected def effectCompat: UnsafeRun[IO] =
         weaver.framework.test.Meta.SetTimeUnsafeRun
 
       override def isCI = false
@@ -140,7 +140,7 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object TestRunnerArgs extends SimpleIOSuite {
-      override implicit protected def effectCompat: UnsafeRun[IO] =
+      override protected def effectCompat: UnsafeRun[IO] =
         weaver.framework.test.Meta.SetTimeUnsafeRun
 
       pureTest("(matches-args)") {
@@ -153,7 +153,7 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object TestRunnerArgsWithOnly extends SimpleIOSuite {
-      override implicit protected def effectCompat: UnsafeRun[IO] =
+      override protected def effectCompat: UnsafeRun[IO] =
         weaver.framework.test.Meta.SetTimeUnsafeRun
 
       override def isCI = false


### PR DESCRIPTION
The `EffectCompat` typeclass combines `Async` and `Parallel` instances, and has a few overridable helper functions.

In particular, the `realTimeMillis` function is used to override the clock time when testing.

`EffectCompat` is present in the `Test` class signature. Users who implement their own `SharedResourceSuite` must construct a `Test`, so must have access to an `EffectCompat`. This can be confusing.

This PR replaces `EffectCompat` implicit with cats-effect typeclasses. The `EffectCompat` instance is deconstructed into `Clock`, `Defer` and `Concurrent`, such that the `Clock` can be replaced during testing.