### PR TITLE
Make JUnit integration JVM-specific

### DIFF
--- a/modules/core-cats/shared/src/main/scala/weaver/BaseIOSuite.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/BaseIOSuite.scala
@@ -2,6 +2,6 @@ package weaver
 
 import cats.effect.IO
 
-trait BaseIOSuite extends RunnableSuite[IO] with BaseCatsSuite {
+trait BaseIOSuite extends EffectSuite[IO] with BaseCatsSuite {
   protected def effectCompat: UnsafeRun[IO] = CatsUnsafeRun
 }

--- a/modules/core/js-native/src/main/scala/weaver/SharedResourceRunnableSuite.scala
+++ b/modules/core/js-native/src/main/scala/weaver/SharedResourceRunnableSuite.scala
@@ -1,0 +1,6 @@
+package weaver
+
+/**
+ * Stub implementation. The JS and Native SharedResourceSuite is not runnable.
+ */
+private[weaver] trait SharedResourceRunnableSuite[F[_]] extends EffectSuite[F]

--- a/modules/core/js/src/main/scala/org/junit/runner/RunWith.scala
+++ b/modules/core/js/src/main/scala/org/junit/runner/RunWith.scala
@@ -1,9 +1,0 @@
-package org.junit.runner
-
-import org.typelevel.scalaccompat.annotation.unused
-
-/**
- * Stub used for cross-compilation
- */
-class RunWith[T](@unused cls: Class[T])
-    extends scala.annotation.StaticAnnotation

--- a/modules/core/js/src/main/scala/weaver/junit/WeaverRunner.scala
+++ b/modules/core/js/src/main/scala/weaver/junit/WeaverRunner.scala
@@ -1,6 +1,0 @@
-package weaver.junit
-
-/**
- * Stub used for cross-compilation
- */
-class WeaverRunner()

--- a/modules/core/jvm/src/main/scala/weaver/RunnableSuite.scala
+++ b/modules/core/jvm/src/main/scala/weaver/RunnableSuite.scala
@@ -1,0 +1,22 @@
+package weaver
+
+import org.junit.runner.RunWith
+
+/**
+ * A suite that can be executed without a provided runtime.
+ *
+ * This is required for JUnit integration. JUnit is used to run suites
+ * individually in IntelliJ.
+ */
+@RunWith(classOf[weaver.junit.WeaverRunner])
+private[weaver] abstract class RunnableSuite[F[_]] extends EffectSuite[F] {
+
+  override protected def effectCompat: UnsafeRun[EffectType]
+  private[weaver] def getEffectCompat: UnsafeRun[EffectType] = effectCompat
+
+  private[weaver] def runUnsafe(report: TestOutcome => Unit): Unit =
+    effectCompat.unsafeRunSync(run(List.empty)(outcome =>
+      effectCompat.effect.delay(report(outcome))))
+
+  private[weaver] def plan: junit.WeaverRunnerPlan
+}

--- a/modules/core/jvm/src/main/scala/weaver/SharedResourceRunnableSuite.scala
+++ b/modules/core/jvm/src/main/scala/weaver/SharedResourceRunnableSuite.scala
@@ -1,0 +1,11 @@
+package weaver
+
+import weaver.junit.WeaverRunnerPlan
+
+private[weaver] trait SharedResourceRunnableSuite[F[_]]
+    extends RunnableSuite[F] {
+  self: SharedResourceSuite[F] =>
+
+  private[weaver] final def plan: WeaverRunnerPlan =
+    WeaverRunnerPlan(self.analyze(self.testSeq.toList, List.empty))
+}

--- a/modules/core/jvm/src/main/scala/weaver/junit/Reflection.scala
+++ b/modules/core/jvm/src/main/scala/weaver/junit/Reflection.scala
@@ -1,0 +1,38 @@
+package weaver
+package junit
+
+import scala.util.control.NoStackTrace
+
+import org.portablescala.reflect.Reflect
+
+private object Reflection {
+
+  private[junit] type AnyEffect[A] = Any
+
+  private[junit] def loadRunnableSuite[A](
+      qualifiedName: String,
+      loader: ClassLoader): RunnableSuite[AnyEffect] =
+    Reflect.lookupLoadableModuleClass(qualifiedName, loader) match {
+      case Some(cls) => cls.loadModule().asInstanceOf[RunnableSuite[AnyEffect]]
+      case None      =>
+        Reflect.lookupInstantiatableClass(qualifiedName, loader) match {
+          case None =>
+            throw new Exception(s"Could not find class $qualifiedName")
+              with NoStackTrace
+          case Some(cls) =>
+            cls.getConstructor(classOf[GlobalResourceF.Read[AnyEffect]]) match {
+              case Some(value) =>
+                // Instantiating with null a first time to retrieve the effect...
+                val unused =
+                  value.newInstance(null).asInstanceOf[RunnableSuite[AnyEffect]]
+                val effectCompat = unused.getEffectCompat
+                val read = GlobalResourceF.Read.empty(effectCompat.effect)
+                // Re-instantiating with empty global read.
+                value.newInstance(read).asInstanceOf[RunnableSuite[AnyEffect]]
+              case None =>
+                throw new Exception("Could not find a suitable constructor that takes GlobalResourceF.Read")
+            }
+        }
+
+    }
+}

--- a/modules/core/jvm/src/main/scala/weaver/junit/WeaverRunner.scala
+++ b/modules/core/jvm/src/main/scala/weaver/junit/WeaverRunner.scala
@@ -4,11 +4,14 @@ package junit
 import org.typelevel.scalaccompat.annotation.unused
 
 import weaver.TestStatus._
-import weaver.internals.Reflection
 
 import org.junit.runner.Description
 import org.junit.runner.notification.RunNotifier
 
+/**
+ * Runner for the JUnit integration. JUnit is used to run individual suites in
+ * IntelliJ.
+ */
 class WeaverRunner(cls: Class[_], @unused dummy: Boolean)
     extends org.junit.runner.Runner {
 
@@ -16,11 +19,11 @@ class WeaverRunner(cls: Class[_], @unused dummy: Boolean)
 
   def this(cls: Class[_]) = this(cls, true)
 
-  lazy val suite: RunnableSuite[F] = {
+  private lazy val suite: RunnableSuite[F] = {
     Reflection.loadRunnableSuite(cls.getName(), getClass().getClassLoader())
   }
 
-  def testDescriptions: Map[String, Description] = {
+  private def testDescriptions: Map[String, Description] = {
     (suite.plan.ignoredTests ++ suite.plan.filteredTests).map(name =>
       name -> Description.createTestDescription(cls, name)).toMap
   }
@@ -40,23 +43,24 @@ class WeaverRunner(cls: Class[_], @unused dummy: Boolean)
     notifier.fireTestSuiteFinished(desc)
   }
 
-  def notifiying(notifier: RunNotifier): TestOutcome => Unit = outcome => {
-    val description = desc(outcome)
-    outcome.status match {
-      case Success =>
-        notifier.fireTestStarted(description)
-        notifier.fireTestFinished(description)
-      case Failure =>
-        notifier.fireTestStarted(description)
-        notifier.fireTestFailure(assertionFailed(outcome))
-        notifier.fireTestFinished(description)
-      case weaver.TestStatus.Exception =>
-        notifier.fireTestStarted(description)
-        notifier.fireTestFailure(failure(outcome))
-      case Ignored =>
-        notifier.fireTestIgnored(description)
+  private def notifiying(notifier: RunNotifier): TestOutcome => Unit =
+    outcome => {
+      val description = desc(outcome)
+      outcome.status match {
+        case Success =>
+          notifier.fireTestStarted(description)
+          notifier.fireTestFinished(description)
+        case Failure =>
+          notifier.fireTestStarted(description)
+          notifier.fireTestFailure(assertionFailed(outcome))
+          notifier.fireTestFinished(description)
+        case weaver.TestStatus.Exception =>
+          notifier.fireTestStarted(description)
+          notifier.fireTestFailure(failure(outcome))
+        case Ignored =>
+          notifier.fireTestIgnored(description)
+      }
     }
-  }
 
   private def notifyIgnored(notifier: RunNotifier): Unit = {
     suite.plan.ignoredTests

--- a/modules/core/jvm/src/main/scala/weaver/junit/WeaverRunnerPlan.scala
+++ b/modules/core/jvm/src/main/scala/weaver/junit/WeaverRunnerPlan.scala
@@ -1,0 +1,20 @@
+package weaver
+package junit
+
+/**
+ * A list of all tests within a suite.
+ *
+ * When a suite is executed by the JUnit-based IDE, a progress indicator is
+ * displayed for each test name.
+ */
+private[weaver] case class WeaverRunnerPlan(
+    ignoredTests: List[String],
+    filteredTests: List[String])
+private[weaver] object WeaverRunnerPlan {
+  def apply(result: TagAnalysisResult[_]): WeaverRunnerPlan = result match {
+    case TagAnalysisResult.Outcomes(ignored, outcomes) =>
+      WeaverRunnerPlan(ignored.toList, outcomes.map(_.name).toList)
+    case TagAnalysisResult.FilteredTests(ignored, tests) =>
+      WeaverRunnerPlan(ignored.toList, tests.map(_._1).toList)
+  }
+}

--- a/modules/core/native/src/main/scala/org/junit/runner/RunWith.scala
+++ b/modules/core/native/src/main/scala/org/junit/runner/RunWith.scala
@@ -1,8 +1,0 @@
-package org.junit.runner
-import org.typelevel.scalaccompat.annotation.unused
-
-/**
- * Stub used for cross-compilation
- */
-class RunWith[T](@unused cls: Class[T])
-    extends scala.annotation.StaticAnnotation

--- a/modules/core/native/src/main/scala/weaver/junit/WeaverRunner.scala
+++ b/modules/core/native/src/main/scala/weaver/junit/WeaverRunner.scala
@@ -1,6 +1,0 @@
-package weaver.junit
-
-/**
- * Stub used for cross-compilation
- */
-class WeaverRunner()

--- a/modules/core/shared/src/main/scala/weaver/internals/Reflection.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/Reflection.scala
@@ -8,35 +8,6 @@ import org.portablescala.reflect.Reflect
 
 private[weaver] object Reflection {
 
-  private[weaver] type AnyEffect[A] = Any
-
-  private[weaver] def loadRunnableSuite[A](
-      qualifiedName: String,
-      loader: ClassLoader): RunnableSuite[AnyEffect] =
-    Reflect.lookupLoadableModuleClass(qualifiedName, loader) match {
-      case Some(cls) => cls.loadModule().asInstanceOf[RunnableSuite[AnyEffect]]
-      case None      =>
-        Reflect.lookupInstantiatableClass(qualifiedName, loader) match {
-          case None =>
-            throw new Exception(s"Could not find class $qualifiedName")
-              with NoStackTrace
-          case Some(cls) =>
-            cls.getConstructor(classOf[GlobalResourceF.Read[AnyEffect]]) match {
-              case Some(value) =>
-                // Instantiating with null a first time to retrieve the effect...
-                val unused =
-                  value.newInstance(null).asInstanceOf[RunnableSuite[AnyEffect]]
-                val effectCompat = unused.getEffectCompat
-                val read = GlobalResourceF.Read.empty(effectCompat.effect)
-                // Re-instantiating with empty global read.
-                value.newInstance(read).asInstanceOf[RunnableSuite[AnyEffect]]
-              case None =>
-                throw new Exception("Could not find a suitable constructor that takes GlobalResourceF.Read")
-            }
-        }
-
-    }
-
   private[weaver] def loadConstructor[A, C](
       qualifiedName: String,
       loader: ClassLoader)(

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -7,7 +7,6 @@ import cats.effect.{ Async, Resource }
 
 import fs2.Stream
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
-import org.junit.runner.RunWith
 
 // Just a non-parameterized marker trait to help SBT's test detection logic.
 @EnableReflectiveInstantiation
@@ -34,17 +33,55 @@ trait EffectSuite[F[_]] extends BaseSuiteClass with EffectSuiteAux
   def spec(args: List[String]): Stream[F, TestOutcome]
 }
 
-@RunWith(classOf[weaver.junit.WeaverRunner])
-abstract class RunnableSuite[F[_]] extends EffectSuite[F] {
-  protected def effectCompat: UnsafeRun[EffectType]
-  private[weaver] def getEffectCompat: UnsafeRun[EffectType] = effectCompat
-  private[weaver] def plan: WeaverRunnerPlan
-  private[weaver] def runUnsafe(
-      report: TestOutcome => Unit): Unit =
-    effectCompat.unsafeRunSync(run(List.empty)(outcome =>
-      effectCompat.effect.delay(report(outcome))))
+trait SharedResourceSuiteAux extends EffectSuiteAux {
+  type Res
 
-  def isCI: Boolean = System.getenv("CI") == "true"
+  protected def registerTest(name: TestName)(
+      f: Res => EffectType[TestOutcome]): Unit
+}
+
+abstract class SharedResourceSuite[F[_]] extends SharedResourceRunnableSuite[F]
+    with SharedResourceSuiteAux {
+
+  type Res
+  def sharedResource: Resource[F, Res]
+
+  def maxParallelism: Int = 10000
+
+  protected final def registerTest(name: TestName)(
+      f: Res => F[TestOutcome]): Unit =
+    synchronized {
+      if (isInitialized) throw initError
+      testSeq = testSeq :+ (name -> f)
+    }
+
+  override final def spec(args: List[String]): Stream[F, TestOutcome] =
+    synchronized {
+      if (!isInitialized) isInitialized = true
+      val parallelism = math.max(1, maxParallelism)
+
+      analyze(testSeq, args) match {
+        case TagAnalysisResult.Outcomes(_, outcomes) =>
+          fs2.Stream.emits(outcomes)
+        case TagAnalysisResult.FilteredTests(_, filteredTests)
+            if filteredTests.isEmpty =>
+          Stream.empty // no need to allocate resources
+        case TagAnalysisResult.FilteredTests(_, filteredTests) => for {
+            resource <- Stream.resource(sharedResource)
+            tests      = filteredTests.map(_._2.apply(resource))
+            testStream = Stream.emits(tests).covary[F]
+            result <- if (parallelism > 1)
+              testStream.parEvalMap(parallelism)(identity)(effectCompat.effect)
+            else testStream.evalMap(identity)
+          } yield result
+      }
+    }
+
+  private[weaver] final var testSeq: Seq[(TestName, Res => F[TestOutcome])] =
+    Seq.empty
+
+  private[this] var isInitialized = false
+  def isCI: Boolean               = System.getenv("CI") == "true"
 
   private[weaver] def analyze[A](
       testSeq: Seq[(TestName, A)],
@@ -118,69 +155,6 @@ private[weaver] object TagAnalysisResult {
       extends TagAnalysisResult[A]
 }
 
-private[weaver] case class WeaverRunnerPlan(
-    ignoredTests: List[String],
-    filteredTests: List[String])
-private[weaver] object WeaverRunnerPlan {
-  def apply(result: TagAnalysisResult[_]): WeaverRunnerPlan = result match {
-    case TagAnalysisResult.Outcomes(ignored, outcomes) =>
-      WeaverRunnerPlan(ignored.toList, outcomes.map(_.name).toList)
-    case TagAnalysisResult.FilteredTests(ignored, tests) =>
-      WeaverRunnerPlan(ignored.toList, tests.map(_._1).toList)
-  }
-}
-
-trait SharedResourceSuiteAux extends EffectSuiteAux {
-  type Res
-
-  protected def registerTest(name: TestName)(
-      f: Res => EffectType[TestOutcome]): Unit
-}
-
-abstract class SharedResourceSuite[F[_]] extends RunnableSuite[F]
-    with SharedResourceSuiteAux {
-
-  type Res
-  def sharedResource: Resource[F, Res]
-
-  def maxParallelism: Int = 10000
-
-  protected final def registerTest(name: TestName)(
-      f: Res => F[TestOutcome]): Unit =
-    synchronized {
-      if (isInitialized) throw initError
-      testSeq = testSeq :+ (name -> f)
-    }
-
-  override final def spec(args: List[String]): Stream[F, TestOutcome] =
-    synchronized {
-      if (!isInitialized) isInitialized = true
-      val parallelism = math.max(1, maxParallelism)
-
-      analyze(testSeq, args) match {
-        case TagAnalysisResult.Outcomes(_, outcomes) =>
-          fs2.Stream.emits(outcomes)
-        case TagAnalysisResult.FilteredTests(_, filteredTests)
-            if filteredTests.isEmpty =>
-          Stream.empty // no need to allocate resources
-        case TagAnalysisResult.FilteredTests(_, filteredTests) => for {
-            resource <- Stream.resource(sharedResource)
-            tests      = filteredTests.map(_._2.apply(resource))
-            testStream = Stream.emits(tests).covary[F]
-            result <- if (parallelism > 1)
-              testStream.parEvalMap(parallelism)(identity)(effectCompat.effect)
-            else testStream.evalMap(identity)
-          } yield result
-      }
-    }
-
-  private[this] var testSeq: Seq[(TestName, Res => F[TestOutcome])] = Seq.empty
-
-  private[weaver] final def plan: WeaverRunnerPlan =
-    WeaverRunnerPlan(analyze(testSeq.toList, List.empty))
-
-  private[this] var isInitialized = false
-}
 abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
     registerTest(name)(_ =>

--- a/modules/discipline/js-native/src/main/scala/weaver/discipline/DisciplineFRunnableSuite.scala
+++ b/modules/discipline/js-native/src/main/scala/weaver/discipline/DisciplineFRunnableSuite.scala
@@ -1,0 +1,5 @@
+package weaver
+package discipline
+
+/** Stub implementation. The JS and Native DisciplineFSuite is not runnable. */
+private[discipline] trait DisciplineFRunnableSuite[F[_]] extends EffectSuite[F]

--- a/modules/discipline/jvm/src/main/scala/weaver/discipline/DisciplineFRunnableSuite.scala
+++ b/modules/discipline/jvm/src/main/scala/weaver/discipline/DisciplineFRunnableSuite.scala
@@ -1,0 +1,15 @@
+package weaver
+package discipline
+
+import weaver.RunnableSuite
+import weaver.junit.WeaverRunnerPlan
+
+private[discipline] trait DisciplineFRunnableSuite[F[_]]
+    extends RunnableSuite[F] {
+  self: DisciplineFSuite[F] =>
+
+  private[weaver] override def plan: WeaverRunnerPlan =
+    foundProps.synchronized {
+      WeaverRunnerPlan(Nil, self.foundProps.toList.map(_.name))
+    }
+}

--- a/modules/discipline/shared/src/main/scala/weaver/discipline/Discipline.scala
+++ b/modules/discipline/shared/src/main/scala/weaver/discipline/Discipline.scala
@@ -34,7 +34,7 @@ trait Discipline { self: SharedResourceSuiteAux =>
 
 }
 
-trait DisciplineFSuite[F[_]] extends RunnableSuite[F] {
+trait DisciplineFSuite[F[_]] extends DisciplineFRunnableSuite[F] {
 
   type Res
   def sharedResource: Resource[F, Res]
@@ -105,12 +105,7 @@ trait DisciplineFSuite[F[_]] extends RunnableSuite[F] {
       }
     }
 
-  private[weaver] override def plan: WeaverRunnerPlan =
-    foundProps.synchronized {
-      WeaverRunnerPlan(Nil, foundProps.toList.map(_.name))
-    }
-
-  private[this] val foundProps = mutable.Buffer.empty[TestName]
+  private[weaver] val foundProps = mutable.Buffer.empty[TestName]
 
   private[this] val registeredTests =
     mutable.Buffer.empty[Res => F[List[F[TestOutcome]]]]


### PR DESCRIPTION
The `RunnableSuite` class is used to integrate with JUnit. It provides:
 - A `plan` function, for creating a list of tests to run
 - A `runUnsafe` function for running tests, only used in JUnit
 - The `RunWith` annotation linking it to the `WeaverRunner`.

It is currently shared across all platforms, but is only required for the JVM. 

This introduces some redundancies in the JS and Native implementations. As an example, `unsafeRunSync` is only needed in the JVM implementation, but needs to be implemented for JS and Native.

This PR moves `RunnableSuite` into the `jvm` sources. Suites that extend `RunnableSuite` (`SharedResourceSuite` and `DisciplineFSuite`) have corresponding traits that either extend `RunnableSuite` or `EffectSuite`.

### Changes to the public API
 - `RunnableSuite` is now private to weaver and JVM-only. Users referring to `RunnableSuite` to abstract over tests should refer to `EffectSuite` instead.
 - `isCI` has been moved to `SharedResourceSuite`. This function isn't required by JUnit, or related to running tests. Users of `DisciplineFSuite` can define their own `isCI` function.
 - Some functions on the `weaver.junit.WeaverRunner` are private. Noone should be using these.
 - The `weaver.junit.WeaverRunner` is no longer stubbed for JS and Native. Noone should be using these.

### Example of JUnit integration
This has been tested in IntelliJ to verify that the JUnit integration behaves as before.
<img width="726" height="474" alt="Screenshot 2026-04-21 at 12 09 14" src="https://github.com/user-attachments/assets/2a6303d7-2aab-417b-94c8-2a618605c769" />
