### PR TITLE
Fix typo in README regarding test filter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ When using the IOSuite variants, the user can call `sbt`'s test command as such:
 > testOnly -- -o *foo*
 ```
 
-This filter will prevent the execution of any test that doesn't contain the string "foo" in is qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is:
+This filter will prevent the execution of any test that doesn't contain the string "foo" in its qualified name. For a test labeled "foo" in a "FooSuite" object, in the package "fooPackage", the qualified name of a test is:
 
 ```
 fooPackage.FooSuite.foo


### PR DESCRIPTION
Corrected a typo in the explanation of the test filter.