### PR TITLE
Add baseURL to CI test failures: simulate an error

### DIFF
--- a/docs/features/troubleshooting_failures.md
+++ b/docs/features/troubleshooting_failures.md
@@ -193,6 +193,16 @@ object SourceLocationSuite extends FunSuite {
 println(weaver.docs.Output.runSuites(SourceLocationSuite))
 ```
 
+## Displaying source locations in CI test runs
+
+Source locations in CI runs are displayed as urls. If you use GitHub Actions, the source code URL is determined automatically.
+
+You can display urls in other CI providers using the `WEAVER_SOURCE_URL` environment variable.
+
+```sh
+export WEAVER_SOURCE_URL=https://gitlab.com/my-org/my-repo/-/tree/my-branch/
+```
+
 ## Displaying a trace
 
 If you have a test codebase with many nested helper functions, you may want to display a trace of source locations. You can do this with the `traced(here)` function.

--- a/modules/core-cats/shared/src/main/scala/weaver/CatsUnsafeRun.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/CatsUnsafeRun.scala
@@ -4,6 +4,7 @@ import scala.concurrent.Future
 
 import cats.effect.unsafe.implicits.global
 import cats.effect.{ FiberIO, IO }
+import cats.effect.std.Env
 
 object CatsUnsafeRun extends CatsUnsafeRun
 
@@ -13,6 +14,7 @@ trait CatsUnsafeRun extends UnsafeRun[IO] with CatsUnsafeRunPlatformCompat {
 
   override implicit val parallel = IO.parallelForIO
   override implicit val effect   = IO.asyncForIO
+  override def env: Env[IO]      = IO.envForIO
 
   def cancel(token: CancelToken): Unit = unsafeRunSync(token.cancel)
 

--- a/modules/core/shared/src/main/scala/weaver/Formatter.scala
+++ b/modules/core/shared/src/main/scala/weaver/Formatter.scala
@@ -47,7 +47,7 @@ object Formatter {
       case Success => withPrefix(green("+ "))
       case OnlyTagNotAllowedInCI(_) | Failures(_) | Exception(_) =>
         withPrefix(red("- "))
-      case Ignored(_, _) =>
+      case Ignored(_, _, _) =>
         withPrefix(yellow("- ")) + yellow(" !!! IGNORED !!!")
     }
   }

--- a/modules/core/shared/src/main/scala/weaver/Result.scala
+++ b/modules/core/shared/src/main/scala/weaver/Result.scala
@@ -10,22 +10,29 @@ private[weaver] sealed trait Result {
 private[weaver] object Result {
   import Formatter._
 
-  def fromAssertion(assertion: Expectations): Result = assertion.run match {
-    case Valid(_)        => Success
-    case Invalid(failed) =>
-      Failures(failed.map(ex =>
-        Failures.Failure(ex.message, ex, ex.locations)))
-  }
+  def fromAssertion(
+      sourceLocationUrl: Option[String],
+      assertion: Expectations): Result =
+    assertion.run match {
+      case Valid(_)        => Success
+      case Invalid(failed) =>
+        Failures(failed.map(ex =>
+          Failures.Failure(ex.message, ex, sourceLocationUrl, ex.locations)))
+    }
 
   case object Success extends Result {
     def formatted: Option[String] = None
   }
 
-  final case class Ignored(reason: String, location: SourceLocation)
+  final case class Ignored(
+      reason: String,
+      sourceLocationUrl: Option[String],
+      location: SourceLocation)
       extends Result {
 
     def formatted: Option[String] = {
       Some(formatDescription(reason,
+                             sourceLocationUrl = sourceLocationUrl,
                              List(location),
                              Console.YELLOW,
                              TAB2.prefix))
@@ -40,6 +47,7 @@ private[weaver] object Result {
         val failure          = failures.head
         val formattedMessage = formatDescription(
           failure.msg,
+          failures.head.sourceLocationUrl,
           failure.locations.toList,
           Console.RED,
           TAB2.prefix
@@ -53,6 +61,7 @@ private[weaver] object Result {
 
             formatDescription(
               msg,
+              sourceLocationUrl,
               locations.toList,
               Console.RED,
               s" [$idx] "
@@ -67,6 +76,7 @@ private[weaver] object Result {
     final case class Failure(
         msg: String,
         source: ExpectationFailed,
+        sourceLocationUrl: Option[String],
         locations: NonEmptyList[SourceLocation])
   }
 
@@ -77,6 +87,7 @@ private[weaver] object Result {
     def formatted: Option[String] = {
       val formattedMessage = formatDescription(
         "'Only' tag is not allowed when `isCI=true`",
+        None,
         List(location),
         Console.RED,
         TAB2.prefix
@@ -102,13 +113,13 @@ private[weaver] object Result {
 
   val success: Result = Success
 
-  def from(error: Throwable): Result = {
+  def from(sourceLocationUrl: Option[String], error: Throwable): Result = {
     error match {
       case ex: IgnoredException =>
-        Ignored(ex.reason, ex.location)
+        Ignored(ex.reason, sourceLocationUrl, ex.location)
       case exs: ExpectationsFailed =>
         Failures(exs.failures.map { ex =>
-          Failures.Failure(ex.message, ex, ex.locations)
+          Failures.Failure(ex.message, ex, sourceLocationUrl, ex.locations)
         })
       case other =>
         Exception(other)
@@ -137,6 +148,7 @@ private[weaver] object Result {
 
       if (errorOutputLines.nonEmpty) {
         formatDescription(errorOutputLines.mkString(EOL),
+                          None,
                           Nil,
                           Console.RED,
                           TAB2.prefix)
@@ -145,6 +157,7 @@ private[weaver] object Result {
 
     val formattedMessage = formatDescription(
       msg,
+      None,
       Nil,
       Console.RED,
       TAB2.prefix
@@ -159,12 +172,13 @@ private[weaver] object Result {
 
   private def formatDescription(
       message: String,
+      sourceLocationUrl: Option[String],
       location: List[SourceLocation],
       color: String,
       prefix: String): String = {
 
     val prefixIsWhitespace = prefix.trim.isEmpty
-    val footer             = locationFooter(location)
+    val footer             = locationFooter(sourceLocationUrl, location)
     val lines = (message.split("\\r?\\n") ++ footer).zipWithIndex.map {
       case (line, index) =>
         val linePrefix =
@@ -172,7 +186,7 @@ private[weaver] object Result {
         if (index == 0)
           color + linePrefix + line +
             location
-              .map(l => s" (${l.fileRelativePath}:${l.line})")
+              .map(l => s" (${formatLocationPath(sourceLocationUrl, l)})")
               .mkString("\n")
         else
           color + linePrefix + line
@@ -181,14 +195,30 @@ private[weaver] object Result {
     lines.mkString(EOL) + Console.RESET
   }
 
-  private def locationFooter(locations: List[SourceLocation]): List[String] = {
+  private def locationFooter(
+      sourceLocationUrl: Option[String],
+      locations: List[SourceLocation]): List[String] = {
     val lines = locations.flatMap { l =>
-      val prefix = s"${l.fileRelativePath}:${l.line}"
       l.sourceCode.fold(List.empty[String]) { sourceCode =>
         val pointer = " " * (sourceCode.column - 1) + "^"
-        List(prefix, sourceCode.sourceLine, pointer)
+        List(formatLocationPath(sourceLocationUrl, l),
+             sourceCode.sourceLine,
+             pointer)
       }
     }
     if (lines.nonEmpty) "" :: lines else Nil
   }
+
+  private def formatLocationPath(
+      sourceLocationUrl: Option[String],
+      l: SourceLocation): String =
+    sourceLocationUrl match {
+      case Some(url) =>
+        // Display a URL to a source location on a CI host. Line numbers are typically referenced with #L anchors.
+        s"${url}${l.fileRelativePath}#L${l.line}"
+      case None =>
+        // Display a path to a local file.
+        s"${l.fileRelativePath}:${l.line}"
+    }
+
 }

--- a/modules/core/shared/src/main/scala/weaver/Test.scala
+++ b/modules/core/shared/src/main/scala/weaver/Test.scala
@@ -8,21 +8,25 @@ import cats.data.Chain
 import cats.effect.Ref
 import cats.effect.Clock
 import cats.effect.Concurrent
+import cats.effect.std.Env
 import cats.syntax.all._
-
+import weaver.internals.SourceLocationUrl
 object Test {
 
   def apply[F[_]](name: String, f: Log[F] => F[Expectations])(
       implicit F: Defer[F],
       G: Concurrent[F],
-      C: Clock[F]): F[TestOutcome] = {
+      C: Clock[F],
+      E: Env[F]
+  ): F[TestOutcome] = {
     for {
-      ref   <- Ref[F].of(Chain.empty[Log.Entry])
-      start <- C.realTime
-      res   <- Defer[F]
+      ref       <- Ref[F].of(Chain.empty[Log.Entry])
+      start     <- C.realTime
+      sourceUrl <- SourceLocationUrl[F]
+      res       <- Defer[F]
         .defer(f(Log.collected[F, Chain](ref, C.realTime.map(_.toMillis))))
-        .map(Result.fromAssertion)
-        .handleError(ex => Result.from(ex))
+        .map(Result.fromAssertion(sourceUrl, _))
+        .handleError(ex => Result.from(sourceUrl, ex))
       end  <- C.realTime
       logs <- ref.get
     } yield TestOutcome(name, end - start, res, logs)
@@ -33,8 +37,8 @@ object Test {
     val (attempt, duration) = Try(ex()) -> (System.currentTimeMillis() - start)
 
     val res = attempt match {
-      case Success(assertions) => Result.fromAssertion(assertions)
-      case Failure(e)          => Result.from(e)
+      case Success(assertions) => Result.fromAssertion(None, assertions)
+      case Failure(e)          => Result.from(None, e)
     }
 
     TestOutcome(name, duration.millis, res, Chain.empty)
@@ -43,7 +47,7 @@ object Test {
   def apply[F[_]](name: String, f: F[Expectations])(
       implicit F: Defer[F],
       G: Concurrent[F],
-      C: Clock[F]
+      C: Clock[F],
+      E: Env[F]
   ): F[TestOutcome] = apply[F](name, (_: Log[F]) => f)
-
 }

--- a/modules/core/shared/src/main/scala/weaver/TestOutcome.scala
+++ b/modules/core/shared/src/main/scala/weaver/TestOutcome.scala
@@ -35,8 +35,8 @@ object TestOutcome {
       extends TestOutcome {
 
     def status: TestStatus = result match {
-      case Result.Success       => TestStatus.Success
-      case Result.Ignored(_, _) => TestStatus.Ignored
+      case Result.Success          => TestStatus.Success
+      case Result.Ignored(_, _, _) => TestStatus.Ignored
       case Result.OnlyTagNotAllowedInCI(_) | Result.Failures(_) =>
         TestStatus.Failure
       case Result.Exception(_) => TestStatus.Exception
@@ -47,6 +47,7 @@ object TestOutcome {
       case Result.Failures(failures) =>
         Some(new ExpectationsFailed(failures.map(_.source)))
       case Result.OnlyTagNotAllowedInCI(_) | Result.Ignored(
+            _,
             _,
             _) | Result.Success => None
     }

--- a/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
+++ b/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
@@ -5,10 +5,12 @@ import scala.concurrent.duration.FiniteDuration
 
 import cats.Parallel
 import cats.effect.{ Async, Clock }
+import cats.effect.std.Env
 
 trait EffectCompat[F[_]] {
   implicit def parallel: Parallel[F]
   implicit def effect: Async[F]
+  def env: Env[F]
   protected[weaver] def clock: Clock[F] = effect
 
   private[weaver] final def sleep(duration: FiniteDuration): F[Unit] =

--- a/modules/core/shared/src/main/scala/weaver/internals/SourceLocationUrl.scala
+++ b/modules/core/shared/src/main/scala/weaver/internals/SourceLocationUrl.scala
@@ -1,0 +1,29 @@
+package weaver.internals
+
+import cats.effect.std.Env
+import cats.Monad
+import cats.syntax.all._
+
+/**
+ * Constructs base URL to use for displaying source locations in failure
+ * messages.
+ */
+private[weaver] object SourceLocationUrl {
+  def apply[F[_]](implicit E: Env[F], F: Monad[F]): F[Option[String]] = {
+    // Users can support non-GitHub CIs by setting WEAVER_SOURCE_URL
+    val readWeaverUrl = E.get("WEAVER_SOURCE_URL")
+    // If tests are run on GitHub Actions, construct a URL to the test source code.
+    // See https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
+    val readGitHubUrl = (
+      E.get("GITHUB_SERVER_URL"),
+      E.get("GITHUB_REPOSITORY"),
+      E.get("GITHUB_SHA")
+    ).tupled.map(_.mapN { case (serverUrl, repo, sha) =>
+      s"$serverUrl/$repo/tree/$sha/"
+    })
+    (readWeaverUrl, readGitHubUrl).mapN {
+      case (weaverUrl, gitHubUrl) => weaverUrl.orElse(gitHubUrl)
+    }
+  }
+
+}

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -15,6 +15,7 @@ trait BaseSuiteClass {}
 // A version of EffectSuite that has a type member instead of a type parameter.
 protected[weaver] trait EffectSuiteAux {
   type EffectType[A]
+  protected def effectCompat: EffectCompat[EffectType]
   implicit protected def effect: Async[EffectType]
 }
 
@@ -158,25 +159,38 @@ private[weaver] object TagAnalysisResult {
 abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
     registerTest(name)(_ =>
-      Test(name.name, effect.delay(run))(effect, effect, effectCompat.clock))
+      Test(name.name, effect.delay(run))(effect,
+                                         effect,
+                                         effectCompat.clock,
+                                         effectCompat.env))
   def loggedTest(name: TestName)(run: Log[F] => F[Expectations]): Unit =
     registerTest(name)(_ =>
-      Test[F](name.name, log => run(log))(effect, effect, effectCompat.clock))
+      Test[F](name.name, log => run(log))(effect,
+                                          effect,
+                                          effectCompat.clock,
+                                          effectCompat.env))
   def test(name: TestName): PartiallyAppliedTest =
     new PartiallyAppliedTest(name)
 
   class PartiallyAppliedTest(name: TestName) {
     def apply(run: => F[Expectations]): Unit =
       registerTest(name)(_ =>
-        Test(name.name, run)(effect, effect, effectCompat.clock))
+        Test(name.name, run)(effect,
+                             effect,
+                             effectCompat.clock,
+                             effectCompat.env))
     def apply(run: Res => F[Expectations]): Unit =
       registerTest(name)(res =>
-        Test(name.name, run(res))(effect, effect, effectCompat.clock))
+        Test(name.name, run(res))(effect,
+                                  effect,
+                                  effectCompat.clock,
+                                  effectCompat.env))
     def apply(run: (Res, Log[F]) => F[Expectations]): Unit =
       registerTest(name)(res =>
         Test[F](name.name, log => run(res, log))(effect,
                                                  effect,
-                                                 effectCompat.clock))
+                                                 effectCompat.clock,
+                                                 effectCompat.env))
 
     // this alias helps using pattern matching on `Res`
     def usingRes(run: Res => F[Expectations]): Unit = apply(run)
@@ -189,7 +203,11 @@ abstract class FunSuiteF[F[_]] extends SharedResourceSuite[F] {
   override final def maxParallelism: Int      = 1
 
   def test(name: TestName)(run: => Expectations): Unit =
-    registerTest(name)(_ => effect.pure(Test.pure(name.name)(() => run)))
+    registerTest(name)(_ =>
+      Test(name.name, effect.delay(run))(effect,
+                                         effect,
+                                         effectCompat.clock,
+                                         effectCompat.env))
 
 }
 

--- a/modules/discipline/shared/src/main/scala/weaver/discipline/Discipline.scala
+++ b/modules/discipline/shared/src/main/scala/weaver/discipline/Discipline.scala
@@ -27,8 +27,13 @@ trait Discipline { self: SharedResourceSuiteAux =>
       case (id, prop) =>
         val testName = name.copy(s"${name.name}: $id")
         registerTest(testName) { _ =>
-          effect.pure(Test.pure(testName.name)(() =>
-            executeProp(prop, name.location, parameters)))
+          Test(testName.name,
+               effect.delay(executeProp(prop, name.location, parameters)))(
+            effect,
+            effect,
+            effectCompat.clock,
+            effectCompat.env
+          )
         }
     }
 
@@ -78,7 +83,12 @@ trait DisciplineFSuite[F[_]] extends DisciplineFRunnableSuite[F] {
             foundProps.synchronized {
               foundProps += name.copy(propTestName)
             }
-            Test(propTestName, runProp)
+            Test(propTestName, runProp)(
+              effect,
+              effect,
+              effectCompat.clock,
+              effectCompat.env
+            )
         }).run
       )
     }

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -326,6 +326,41 @@ object DogFoodTests extends IOSuite {
     }
   }
 
+  test("source locations are rendered with URLs") {
+    _.runSuite(Meta.SourceUrlSuite).flatMap {
+      case (logs, _) =>
+        val actual = extractFailureMessageForTest(logs, "(failure)")
+        if (ScalaCompat.isScala3)
+          assertInlineSnapshot(
+            actual,
+            """- (failure) 0ms
+  Values not equal: (https://github.com/typelevel/weaver-test/blob/v0.12.0/modules/framework-cats/shared/src/test/scala/Meta.scala#L52)
+
+  in expect.eql(- expected, + found)
+  -1
+  +2
+
+  https://github.com/typelevel/weaver-test/blob/v0.12.0/modules/framework-cats/shared/src/test/scala/Meta.scala#L52
+        IO(expect.eql(1, 2))
+                          ^"""
+          )
+        else
+          assertInlineSnapshot(
+            actual,
+            """- (failure) 0ms
+  Values not equal: (https://github.com/typelevel/weaver-test/blob/v0.12.0/modules/framework-cats/shared/src/test/scala/Meta.scala#L52)
+
+  in expect.eql(- expected, + found)
+  -1
+  +2
+
+  https://github.com/typelevel/weaver-test/blob/v0.12.0/modules/framework-cats/shared/src/test/scala/Meta.scala#L52
+        IO(expect.eql(1, 2))
+                     ^"""
+          )
+    }
+  }
+
   test("successes with clues are rendered correctly") {
     _.runSuite(Meta.Clue).flatMap {
       case (logs, _) =>

--- a/modules/framework-cats/shared/src/test/scala/ExpectationsTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/ExpectationsTests.scala
@@ -103,4 +103,7 @@ object ExpectationsTests extends SimpleIOSuite {
         failure("unexpected run of success handler given failure payload")))
   }
 
+  pureTest("should fail") {
+    expect.eql(1, 2)
+  }
 }

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -45,6 +45,14 @@ object Meta {
     }
   }
 
+  object SourceUrlSuite extends SimpleIOSuite {
+    override protected def effectCompat: UnsafeRun[IO] = SourceUrlUnsafeRun
+
+    test("(failure)") {
+      IO(expect.eql(1, 2))
+    }
+  }
+
   object MutableSuiteTest extends MutableSuiteTest
 
   object Boom extends Error("Boom") with scala.util.control.NoStackTrace
@@ -330,6 +338,7 @@ object Meta {
 
   object SetTimeUnsafeRun extends CatsUnsafeRun {
     import scala.concurrent.duration._
+    import cats.effect.std.Env
 
     private val setTimestamp = weaver.internals.Timestamp.localTime(12, 54, 35)
 
@@ -337,6 +346,26 @@ object Meta {
       def realTime: cats.effect.IO[FiniteDuration]  = IO(setTimestamp.millis)
       def monotonic: cats.effect.IO[FiniteDuration] = IO(0L.millis)
       def applicative: cats.Applicative[cats.effect.IO] = cats.Applicative[IO]
+    }
+
+    // Override the environment variables such that local error messages are displayed in CI runs.
+    override def env: Env[IO] = new Env[IO] {
+      def entries: IO[List[(String, String)]]   = IO.pure(Nil)
+      def get(name: String): IO[Option[String]] = IO.pure(None)
+    }
+  }
+
+  object SourceUrlUnsafeRun extends CatsUnsafeRun {
+    import cats.effect.std.Env
+
+    override def clock: Clock[IO] = SetTimeUnsafeRun.clock
+
+    override def env: Env[IO] = new Env[IO] {
+      def entries: IO[List[(String, String)]] = IO(List(
+        ("WEAVER_SOURCE_URL",
+         "https://github.com/typelevel/weaver-test/blob/v0.12.0/")
+      ))
+      def get(name: String): IO[Option[String]] = entries.map(_.toMap.get(name))
     }
   }
 

--- a/modules/framework/js-native/src/main/scala/RunnerCompat.scala
+++ b/modules/framework/js-native/src/main/scala/RunnerCompat.scala
@@ -131,7 +131,7 @@ trait RunnerCompat[F[_]] { self: sbt.testing.Runner =>
         val outcome =
           TestOutcome("Unexpected failure",
                       0.seconds,
-                      Result.from(error),
+                      Result.from(sourceLocationUrl = None, error),
                       Chain.empty)
         reportTest(outcome).productR(
           reportDoneF(TestOutcomeNative.from(fqn)(outcome)))

--- a/modules/framework/jvm/src/main/scala/RunnerCompat.scala
+++ b/modules/framework/jvm/src/main/scala/RunnerCompat.scala
@@ -233,7 +233,7 @@ trait RunnerCompat[F[_]] { self: sbt.testing.Runner =>
           val outcome =
             TestOutcome("Unexpected failure",
                         0.seconds,
-                        Result.from(error),
+                        Result.from(sourceLocationUrl = None, error),
                         Chain.empty)
 
           Async[F].guarantee(outcomes


### PR DESCRIPTION
This is a POC PR for displaying a URL in failures in CI runs.

It's experimental, and is being opened purely to see displays in GitHub Actions logs.