### PR TITLE
Align `stripMargin` calls using scalafmt.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -22,6 +22,8 @@ newlines.alwaysBeforeMultilineDef = false
 newlines.implicitParamListModifierPrefer = before
 newlines.sometimesBeforeColonInMethodReturnType = false
 
+assumeStandardLibraryStripMargin = true
+
 spaces {
   inImportCurlyBraces = true
 }

--- a/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
+++ b/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
@@ -58,13 +58,14 @@ object JUnitRunnerTests extends SimpleIOSuite {
       def testFailure(name: String, lineNumber: Int, sourceCode: String) = {
         val srcPath =
           "modules/framework-cats/jvm/src/test/scala/junit/Meta.scala"
-        val message = s"""- $name 0ms
-          |  'Only' tag is not allowed when `isCI=true` ($srcPath:$lineNumber)
-          |
-          |  $srcPath:$lineNumber
-          |${sourceCode.trim.stripMargin}
-          |
-          |""".stripMargin
+        val message =
+          s"""- $name 0ms
+             |  'Only' tag is not allowed when `isCI=true` ($srcPath:$lineNumber)
+             |
+             |  $srcPath:$lineNumber
+             |${sourceCode.trim.stripMargin}
+             |
+             |""".stripMargin
         TestFailure(
           name = name + "(weaver.junit.Meta$OnlyFailsOnCi$)",
           message = message
@@ -166,13 +167,14 @@ object JUnitRunnerTests extends SimpleIOSuite {
                  |      pureTest("only and ignored".only.ignore) {
                  |                                  ^
                """
-        val message = s"""- $name 0ms
-          |  'Only' tag is not allowed when `isCI=true` ($srcPath:$lineNumber)
-          |
-          |  $srcPath:$lineNumber
-          |${sourceCode.trim.stripMargin}
-          |
-          |""".stripMargin
+        val message =
+          s"""- $name 0ms
+             |  'Only' tag is not allowed when `isCI=true` ($srcPath:$lineNumber)
+             |
+             |  $srcPath:$lineNumber
+             |${sourceCode.trim.stripMargin}
+             |
+             |""".stripMargin
         TestFailure(
           name = name + "(weaver.junit.Meta$OnlyFailsOnCiEvenIfIgnored$)",
           message = message

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -112,14 +112,14 @@ object DogFoodTests extends IOSuite {
 
         val expected =
           s"""
-            |- erroring with a long message: ${Meta.ErroringWithLongPayload.smiles} 0ms
-            |  Meta$$CustomException: surfaced error
-            |
-            |  DogFoodTests.scala:15    my.package.MyClass#MyMethod
-            |  DogFoodTests.scala:20    my.package.ClassOfDifferentLength#method$$new$$1
-            |  <snipped>                cats.effect.internals.<...>
-            |  <snipped>                java.util.concurrent.<...>
-            |""".stripMargin.trim
+             |- erroring with a long message: ${Meta.ErroringWithLongPayload.smiles} 0ms
+             |  Meta$$CustomException: surfaced error
+             |
+             |  DogFoodTests.scala:15    my.package.MyClass#MyMethod
+             |  DogFoodTests.scala:20    my.package.ClassOfDifferentLength#method$$new$$1
+             |  <snipped>                cats.effect.internals.<...>
+             |  <snipped>                java.util.concurrent.<...>
+             |""".stripMargin.trim
 
         expect.same(actual, expected)
     }
@@ -311,17 +311,17 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (failFast) 0ms
-| [0] Values not equal: (src/main/DogFoodTests.scala:5)
-| [0] 
-| [0] in expect.eql(- expected, + found)
-| [0] -1
-| [0] +2
-|
-| [1] Values not equal: (src/main/DogFoodTests.scala:5)
-| [1] 
-| [1] in expect.eql(- expected, + found)
-| [1] -3
-| [1] +4""".stripMargin
+             | [0] Values not equal: (src/main/DogFoodTests.scala:5)
+             | [0] 
+             | [0] in expect.eql(- expected, + found)
+             | [0] -1
+             | [0] +2
+             |
+             | [1] Values not equal: (src/main/DogFoodTests.scala:5)
+             | [1] 
+             | [1] in expect.eql(- expected, + found)
+             | [1] -3
+             | [1] +4""".stripMargin
         )
     }
   }

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -79,10 +79,10 @@ object Meta {
       val show: Show[Foo] = Show.show[Foo] {
         case Foo(s, i) =>
           s"""
-          |Foo {
-          |  s: ${Show[String].show(s)}
-          |  i: ${Show[Int].show(i)}
-          |}
+             |Foo {
+             |  s: ${Show[String].show(s)}
+             |  i: ${Show[Int].show(i)}
+             |}
           """.stripMargin.trim()
       }
       implicit val comparison: Comparison[Foo] =

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -233,9 +233,9 @@ object Checkers {
 
   private def failureMessage(ith: Int, seed: Seed, input: String): String =
     s"""Property test failed on try $ith with seed ${seed} and input $input.
-                |You can reproduce this by adding the following configuration to your test:
-                |
-                |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.$seed.toOption))""".stripMargin
+       |You can reproduce this by adding the following configuration to your test:
+       |
+       |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.$seed.toOption))""".stripMargin
 
   private class PropertyTestError(
       ith: Int,

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -26,12 +26,13 @@ object PropertyDogFoodTest extends IOSuite {
       val attempt = Meta.FailedChecks.failedAttempt
       val value   = Meta.FailedChecks.failedValue
 
-      val expected = s"""(pure)
-          |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
-          |You can reproduce this by adding the following configuration to your test:
-          |
-          |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
-        .stripMargin
+      val expected =
+        s"""(pure)
+           |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+           |You can reproduce this by adding the following configuration to your test:
+           |
+           |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
+          .stripMargin
       expectMessageContains(expected, log)
     }
   }
@@ -45,12 +46,13 @@ object PropertyDogFoodTest extends IOSuite {
         val attempt = Meta.FailedChecks.failedAttempt
         val value   = Meta.FailedChecks.failedValue
 
-        val expected = s"""(failFast)
-          |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
-          |You can reproduce this by adding the following configuration to your test:
-          |
-          |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
-          .stripMargin
+        val expected =
+          s"""(failFast)
+             |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+             |You can reproduce this by adding the following configuration to your test:
+             |
+             |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
+            .stripMargin
         expectMessageContains(expected, errorLog)
       }
     }
@@ -65,15 +67,16 @@ object PropertyDogFoodTest extends IOSuite {
       val attempt = Meta.FailedChecks.failedAttempt
       val value   = Meta.FailedChecks.failedValue
 
-      val expected = s"""(error)
-          |PropertyTestError: Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
-          |You can reproduce this by adding the following configuration to your test:
-          |
-          |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))
-          |
-          |
-          | Caused by: weaver.scalacheck.Meta$$Boom$$: Boom"""
-        .stripMargin
+      val expected =
+        s"""(error)
+           |PropertyTestError: Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+           |You can reproduce this by adding the following configuration to your test:
+           |
+           |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))
+           |
+           |
+           | Caused by: weaver.scalacheck.Meta$$Boom$$: Boom"""
+          .stripMargin
       expectMessageContains(expected, errorLog)
     }
   }


### PR DESCRIPTION
Our tests use `snapshot4s`, which [automatically adds stripMargin calls](https://siriusxm.github.io/snapshot4s/limitations/#promoted-code-isnt-formatted) to multi-line strings. `assumeStandardLibraryStripMargin` is recommended to format these strings.

This PR is a formatting change applying `assumeStandardLibraryStripMargin` to the entire codebase.