### PR TITLE
Remove `Clock` in favour of stripping timestamp from error messages.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Test.scala
+++ b/modules/core/shared/src/main/scala/weaver/Test.scala
@@ -3,27 +3,23 @@ package weaver
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
-import cats.Defer
 import cats.data.Chain
 import cats.effect.Ref
-import cats.effect.Clock
-import cats.effect.Concurrent
+import cats.effect.Async
 import cats.syntax.all._
 
 object Test {
 
   def apply[F[_]](name: String, f: Log[F] => F[Expectations])(
-      implicit F: Defer[F],
-      G: Concurrent[F],
-      C: Clock[F]): F[TestOutcome] = {
+      implicit F: Async[F]): F[TestOutcome] = {
     for {
       ref   <- Ref[F].of(Chain.empty[Log.Entry])
-      start <- C.realTime
-      res   <- Defer[F]
-        .defer(f(Log.collected[F, Chain](ref, C.realTime.map(_.toMillis))))
-        .map(Result.fromAssertion)
-        .handleError(ex => Result.from(ex))
-      end  <- C.realTime
+      start <- F.realTime
+      res   <-
+        F.defer(f(Log.collected[F, Chain](ref, F.realTime.map(_.toMillis))))
+          .map(Result.fromAssertion)
+          .handleError(ex => Result.from(ex))
+      end  <- F.realTime
       logs <- ref.get
     } yield TestOutcome(name, end - start, res, logs)
   }
@@ -41,9 +37,7 @@ object Test {
   }
 
   def apply[F[_]](name: String, f: F[Expectations])(
-      implicit F: Defer[F],
-      G: Concurrent[F],
-      C: Clock[F]
+      implicit F: Async[F]
   ): F[TestOutcome] = apply[F](name, (_: Log[F]) => f)
 
 }

--- a/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
+++ b/modules/core/shared/src/main/scala/weaver/UnsafeRun.scala
@@ -4,12 +4,11 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 import cats.Parallel
-import cats.effect.{ Async, Clock }
+import cats.effect.Async
 
 trait EffectCompat[F[_]] {
   implicit def parallel: Parallel[F]
   implicit def effect: Async[F]
-  protected[weaver] def clock: Clock[F] = effect
 
   private[weaver] final def sleep(duration: FiniteDuration): F[Unit] =
     effect.sleep(duration)

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -158,25 +158,23 @@ private[weaver] object TagAnalysisResult {
 abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
     registerTest(name)(_ =>
-      Test(name.name, effect.delay(run))(effect, effect, effectCompat.clock))
+      Test(name.name, effect.delay(run))(effect))
   def loggedTest(name: TestName)(run: Log[F] => F[Expectations]): Unit =
     registerTest(name)(_ =>
-      Test[F](name.name, log => run(log))(effect, effect, effectCompat.clock))
+      Test[F](name.name, log => run(log))(effect))
   def test(name: TestName): PartiallyAppliedTest =
     new PartiallyAppliedTest(name)
 
   class PartiallyAppliedTest(name: TestName) {
     def apply(run: => F[Expectations]): Unit =
       registerTest(name)(_ =>
-        Test(name.name, run)(effect, effect, effectCompat.clock))
+        Test(name.name, run)(effect))
     def apply(run: Res => F[Expectations]): Unit =
       registerTest(name)(res =>
-        Test(name.name, run(res))(effect, effect, effectCompat.clock))
+        Test(name.name, run(res))(effect))
     def apply(run: (Res, Log[F]) => F[Expectations]): Unit =
       registerTest(name)(res =>
-        Test[F](name.name, log => run(res, log))(effect,
-                                                 effect,
-                                                 effectCompat.clock))
+        Test[F](name.name, log => run(res, log))(effect))
 
     // this alias helps using pattern matching on `Res`
     def usingRes(run: Res => F[Expectations]): Unit = apply(run)

--- a/modules/framework-cats/js-native/src/test/scala/Snapshot4sStubs.scala
+++ b/modules/framework-cats/js-native/src/test/scala/Snapshot4sStubs.scala
@@ -22,7 +22,7 @@ object snapshot4s {
 object SnapshotExpectations {
   def assertInlineSnapshot[A](found: A, snapshot: A)(
       implicit @unused config: snapshot4s.SnapshotConfig,
-      comparison: Comparison[A]
-  ): IO[Expectations] =
+      comparison: Comparison[A],
+      loc: SourceLocation): IO[Expectations] =
     IO(Expectations.Helpers.expect.eql(found, snapshot))
 }

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -491,13 +491,13 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (expect-same) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:22)
+  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:19)
 
   in expect.same(- expected, + found)
   -1
   +2
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:22
+  modules/framework-cats/shared/src/test/scala/Meta.scala:19
         expect.same(x, y)
                         ^"""
           )
@@ -505,13 +505,13 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (expect-same) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:22)
+  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:19)
 
   in expect.same(- expected, + found)
   -1
   +2
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:22
+  modules/framework-cats/shared/src/test/scala/Meta.scala:19
         expect.same(x, y)
                    ^"""
           )
@@ -526,23 +526,23 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (multiple) 0ms
- [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:29)
+ [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:26)
  [0] 
  [0] in expect.same(- expected, + found)
  [0] -1
  [0] +2
  [0] 
- [0] modules/framework-cats/shared/src/test/scala/Meta.scala:29
+ [0] modules/framework-cats/shared/src/test/scala/Meta.scala:26
  [0]       expect.same(x, y) && expect.same(y, z)
  [0]                       ^
 
- [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:29)
+ [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:26)
  [1] 
  [1] in expect.same(- expected, + found)
  [1] -2
  [1] +3
  [1] 
- [1] modules/framework-cats/shared/src/test/scala/Meta.scala:29
+ [1] modules/framework-cats/shared/src/test/scala/Meta.scala:26
  [1]       expect.same(x, y) && expect.same(y, z)
  [1]                                            ^"""
           )
@@ -550,23 +550,23 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (multiple) 0ms
- [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:29)
+ [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:26)
  [0] 
  [0] in expect.same(- expected, + found)
  [0] -1
  [0] +2
  [0] 
- [0] modules/framework-cats/shared/src/test/scala/Meta.scala:29
+ [0] modules/framework-cats/shared/src/test/scala/Meta.scala:26
  [0]       expect.same(x, y) && expect.same(y, z)
  [0]                  ^
 
- [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:29)
+ [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:26)
  [1] 
  [1] in expect.same(- expected, + found)
  [1] -2
  [1] +3
  [1] 
- [1] modules/framework-cats/shared/src/test/scala/Meta.scala:29
+ [1] modules/framework-cats/shared/src/test/scala/Meta.scala:26
  [1]       expect.same(x, y) && expect.same(y, z)
  [1]                                       ^"""
           )
@@ -581,21 +581,21 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (traced) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:33)
- (modules/framework-cats/shared/src/test/scala/Meta.scala:40)
+  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:30)
  (modules/framework-cats/shared/src/test/scala/Meta.scala:37)
+ (modules/framework-cats/shared/src/test/scala/Meta.scala:34)
 
   in expect.same(- expected, + found)
   -1
   +2
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:33
+  modules/framework-cats/shared/src/test/scala/Meta.scala:30
         helper
              ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala:40
+  modules/framework-cats/shared/src/test/scala/Meta.scala:37
         expect.same(1, 2).traced(here)
                                     ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala:37
+  modules/framework-cats/shared/src/test/scala/Meta.scala:34
         nestedHelper.traced(here)
                                ^"""
           )
@@ -603,21 +603,21 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (traced) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:33)
- (modules/framework-cats/shared/src/test/scala/Meta.scala:40)
+  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala:30)
  (modules/framework-cats/shared/src/test/scala/Meta.scala:37)
+ (modules/framework-cats/shared/src/test/scala/Meta.scala:34)
 
   in expect.same(- expected, + found)
   -1
   +2
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:33
+  modules/framework-cats/shared/src/test/scala/Meta.scala:30
         helper
         ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala:40
+  modules/framework-cats/shared/src/test/scala/Meta.scala:37
         expect.same(1, 2).traced(here)
                                  ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala:37
+  modules/framework-cats/shared/src/test/scala/Meta.scala:34
         nestedHelper.traced(here)
                             ^"""
           )
@@ -632,13 +632,13 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (interpolator) 0ms
-  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:44)
+  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:41)
 
   expect(x == "2")
 
   Use the `clue` function to troubleshoot
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:44
+  modules/framework-cats/shared/src/test/scala/Meta.scala:41
         forEach(Option(s"$x"))(x => expect(x == "2"))
                                                    ^"""
           )
@@ -646,13 +646,13 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (interpolator) 0ms
-  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:44)
+  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala:41)
 
   expect(x == "2")
 
   Use the `clue` function to troubleshoot
 
-  modules/framework-cats/shared/src/test/scala/Meta.scala:44
+  modules/framework-cats/shared/src/test/scala/Meta.scala:41
         forEach(Option(s"$x"))(x => expect(x == "2"))
                                           ^"""
           )

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -13,9 +13,6 @@ object Meta {
 
   object SourceLocationSuite extends SimpleIOSuite {
 
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
-
     pureTest("(expect-same)") {
       val x = 1
       val y = 2
@@ -55,8 +52,6 @@ object Meta {
   }
 
   object Rendering extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
     pureTest("lots\nof\nmultiline\n(success)") {
@@ -125,8 +120,6 @@ object Meta {
   }
 
   object Clue extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
     pureTest("(success)") {
@@ -189,8 +182,6 @@ object Meta {
   }
 
   object FailingTestStatusReporting extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
     pureTest("I succeeded") {
@@ -207,8 +198,6 @@ object Meta {
   }
 
   object FailingSuiteWithLogs extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
     loggedTest("(failure)") { log =>
@@ -241,8 +230,6 @@ object Meta {
   }
 
   object ErroringWithCauses extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
 
     loggedTest("erroring with causes") { _ =>
       throw CustomException(
@@ -254,8 +241,6 @@ object Meta {
   }
 
   object ErroringWithLongPayload extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
 
     val smiles = ":)" * 1024
 
@@ -270,8 +255,6 @@ object Meta {
   }
 
   object SucceedsWithErrorInLogs extends SimpleIOSuite {
-    override protected def effectCompat: UnsafeRun[IO] =
-      SetTimeUnsafeRun
     implicit val sourceLocation: SourceLocation = TimeCop.sourceLocation
 
     loggedTest("(failure)") { log =>
@@ -326,18 +309,6 @@ object Meta {
       "src/main/DogFoodTests.scala",
       5,
       None)
-  }
-
-  object SetTimeUnsafeRun extends CatsUnsafeRun {
-    import scala.concurrent.duration._
-
-    private val setTimestamp = weaver.internals.Timestamp.localTime(12, 54, 35)
-
-    override def clock: Clock[IO] = new Clock[IO] {
-      def realTime: cats.effect.IO[FiniteDuration]  = IO(setTimestamp.millis)
-      def monotonic: cats.effect.IO[FiniteDuration] = IO(0L.millis)
-      def applicative: cats.Applicative[cats.effect.IO] = cats.Applicative[IO]
-    }
   }
 
 }

--- a/modules/framework-cats/shared/src/test/scala/MutableSuiteTest.scala
+++ b/modules/framework-cats/shared/src/test/scala/MutableSuiteTest.scala
@@ -12,9 +12,9 @@ abstract class MutableSuiteTest extends SimpleIOSuite {
 
   test("sleeping") {
     for {
-      before <- CatsUnsafeRun.clock.realTime.map(_.toMillis)
+      before <- CatsUnsafeRun.effect.realTime.map(_.toMillis)
       _      <- CatsUnsafeRun.sleep(1.seconds)
-      after  <- CatsUnsafeRun.clock.realTime.map(_.toMillis)
+      after  <- CatsUnsafeRun.effect.realTime.map(_.toMillis)
     } yield expect(after - before >= 1000)
   }
 

--- a/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
@@ -120,8 +120,6 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object Only extends SimpleIOSuite {
-      override protected def effectCompat: UnsafeRun[IO] =
-        weaver.framework.test.Meta.SetTimeUnsafeRun
 
       override def isCI = false
       pureTest("(should-run)".only) {
@@ -136,8 +134,6 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object TestRunnerArgs extends SimpleIOSuite {
-      override protected def effectCompat: UnsafeRun[IO] =
-        weaver.framework.test.Meta.SetTimeUnsafeRun
 
       pureTest("(matches-args)") {
         success
@@ -149,8 +145,6 @@ object TagDogFoodTests extends IOSuite {
     }
 
     object TestRunnerArgsWithOnly extends SimpleIOSuite {
-      override protected def effectCompat: UnsafeRun[IO] =
-        weaver.framework.test.Meta.SetTimeUnsafeRun
 
       override def isCI = false
 

--- a/modules/framework/shared/src/main/scala/weaver/framework/DogFood.scala
+++ b/modules/framework/shared/src/main/scala/weaver/framework/DogFood.scala
@@ -147,22 +147,40 @@ private[weaver] class DogFood[F[_]](val framework: WeaverFramework[F])
     override def ansiCodesSupported(): Boolean = false
 
     override def error(msg: String): Unit =
-      add(LoggedEvent.Error(msg))
+      add(LoggedEvent.Error(stripTimestamps(msg)))
 
     override def warn(msg: String): Unit =
-      add(LoggedEvent.Warn(msg))
+      add(LoggedEvent.Warn(stripTimestamps(msg)))
 
     override def info(msg: String): Unit =
-      add(LoggedEvent.Info(msg))
+      add(LoggedEvent.Info(stripTimestamps(msg)))
 
     override def debug(msg: String): Unit =
-      add(LoggedEvent.Debug(msg))
+      add(LoggedEvent.Debug(stripTimestamps(msg)))
 
     override def trace(t: Throwable): Unit =
       add(LoggedEvent.Trace(t))
 
     def get: F[Chain[LoggedEvent]] =
       effect.delay(Chain.fromSeq(logs.toList))
+  }
+
+  /**
+   * Replaces the times in logged events with constants.
+   *
+   *   - Test durations are replaced with 0ms
+   *   - Log timestamps are replaced with 12:54:35
+   *
+   * Ensures that logged events have the same messages, regardless of test
+   * running time.
+   */
+  private def stripTimestamps(msg: String): String = {
+    val durationRx         = """[0-9]+:?[0-9]*(ms|s|min)""".r
+    val dummyDuration      = "0ms"
+    val logTimestampRx     = """\d{1,2}:\d{1,2}:\d{1,2}""".r
+    val dummyTimestamp     = "12:54:35"
+    val msgWithoutDuration = durationRx.replaceAllIn(msg, dummyDuration)
+    logTimestampRx.replaceAllIn(msgWithoutDuration, dummyTimestamp)
   }
 
   private class MemoryEventHandler() extends EventHandler {


### PR DESCRIPTION
https://github.com/typelevel/weaver-test/pull/305 removed `EffectCompat` from the `Test` signature, and replaced it with `Concurrent`, `Defer` and `Clock` typeclasses. These were used instead of `Async` so that the clock could be mocked for testing.

Instead of mocking the clock, the `DogFood` test harness can strip timestamps from test output. This gives a cleaner `Test` signature for the end user.

## Public API changes

The `Test` signature has been modified to accept `Async[F]` instead `EffectCompat[F]` in `v1.12.0`.

The `DogFood` framework's behaviour has changed to have fixed timestamps. This is exposed publicly for anyone who wants to implement their own weaver runner, but isn't used by most users (probably all users).