### PR TITLE
Remove `name` funciton from `EffectSuite`.

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Runner.scala
+++ b/modules/core/shared/src/main/scala/weaver/Runner.scala
@@ -33,7 +33,7 @@ class Runner[F[_]: Async](
                 .spec(args)
                 .compile
                 .toList
-                .map(SpecEvent(suite.name, _))
+                .map(SpecEvent(suite.getClass.getName.replace("$", ""), _))
                 .flatMap(produce(channel))
             }
             .compile

--- a/modules/core/shared/src/main/scala/weaver/Runner.scala
+++ b/modules/core/shared/src/main/scala/weaver/Runner.scala
@@ -33,7 +33,7 @@ class Runner[F[_]: Async](
                 .spec(args)
                 .compile
                 .toList
-                .map(SpecEvent(suite.getClass.getName.replace("$", ""), _))
+                .map(SpecEvent(suite.suiteName, _))
                 .flatMap(produce(channel))
             }
             .compile

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -25,8 +25,6 @@ trait EffectSuite[F[_]] extends BaseSuiteClass with EffectSuiteAux
   protected def effectCompat: EffectCompat[F]
   implicit final protected def effect: Async[F] = effectCompat.effect
 
-  def name: String = self.getClass.getName.replace("$", "")
-
   final def run(args: List[String])(report: TestOutcome => F[Unit]): F[Unit] =
     spec(args).evalMap(report).compile.drain
 
@@ -111,7 +109,8 @@ abstract class SharedResourceSuite[F[_]] extends SharedResourceRunnableSuite[F]
       // "foo".only.ignore. Use the argument filters to determine the
       // tests to be run.
 
-      val argsFilter = Filters.filterTests(this.name)(args)
+      val suiteName  = this.getClass.getName.replace("$", "")
+      val argsFilter = Filters.filterTests(suiteName)(args)
 
       val testsIgnored =
         testsTaggedOnlyAndIgnored ++

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -25,6 +25,8 @@ trait EffectSuite[F[_]] extends BaseSuiteClass with EffectSuiteAux
   protected def effectCompat: EffectCompat[F]
   implicit final protected def effect: Async[F] = effectCompat.effect
 
+  def suiteName: String = self.getClass.getName.replace("$", "")
+
   final def run(args: List[String])(report: TestOutcome => F[Unit]): F[Unit] =
     spec(args).evalMap(report).compile.drain
 
@@ -109,8 +111,7 @@ abstract class SharedResourceSuite[F[_]] extends SharedResourceRunnableSuite[F]
       // "foo".only.ignore. Use the argument filters to determine the
       // tests to be run.
 
-      val suiteName  = this.getClass.getName.replace("$", "")
-      val argsFilter = Filters.filterTests(suiteName)(args)
+      val argsFilter = Filters.filterTests(this.suiteName)(args)
 
       val testsIgnored =
         testsTaggedOnlyAndIgnored ++


### PR DESCRIPTION
All weaver suites have a publicly accessible `name` field corresponding to their class name.

This is confusing for users, who may reference it in their tests by mistake:

```scala
import weaver.*

object FooSuite extends SimpleIOSuite {
  pureTest("name should be foo") {
    val nam = "foo" // a typo
    expect("foo", name)
  }
}
```

This field should either be removed, or renamed to the more descriptive `suiteName`.