### PR TITLE
Rename mutable suites to type alias names.

### DIFF
--- a/modules/core-cats/shared/src/main/scala/weaver/Suites.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/Suites.scala
@@ -4,15 +4,25 @@ import cats.effect.{ IO, Resource }
 
 trait BaseCatsSuite extends EffectSuite[IO]
 
-abstract class MutableIOSuite
-    extends MutableFSuite[IO]
+/**
+ * Extend this when each test in the suite returns an `Resource[IO, Res]` for
+ * some shared resource `Res`
+ */
+abstract class IOSuite
+    extends FSuite[IO]
     with BaseIOSuite
     with Expectations.Helpers
 
-abstract class SimpleMutableIOSuite extends MutableIOSuite {
+/**
+ * Extend this when each test in the suite returns an `IO[_]`
+ */
+abstract class SimpleIOSuite extends IOSuite {
   type Res = Unit
   def sharedResource: Resource[IO, Unit] = Resource.pure[IO, Unit](())
 }
 
-trait FunSuiteIO extends FunSuiteF[IO] with BaseIOSuite
+/**
+ * Extend this when each test in the suite is pure and does not return `IO[_]`
+ */
+trait FunSuite extends FunSuiteF[IO] with BaseIOSuite
     with Expectations.Helpers

--- a/modules/core-cats/shared/src/main/scala/weaver/package.scala
+++ b/modules/core-cats/shared/src/main/scala/weaver/package.scala
@@ -2,23 +2,7 @@ import cats.effect.IO
 
 package object weaver {
 
-  /**
-   * Extend this when each test in the suite returns an `Resource[IO, Res]` for
-   * some shared resource `Res`
-   */
-  type IOSuite = MutableIOSuite
-
-  /**
-   * Extend this when each test in the suite returns an `IO[_]`
-   */
-  type SimpleIOSuite = SimpleMutableIOSuite
-
   type GlobalResource = IOGlobalResource
   type GlobalRead     = GlobalResourceF.Read[IO]
   type GlobalWrite    = GlobalResourceF.Write[IO]
-
-  /**
-   * Extend this when each test in the suite is pure and does not return `IO[_]`
-   */
-  type FunSuite = FunSuiteIO
 }

--- a/modules/core/shared/src/main/scala/weaver/suites.scala
+++ b/modules/core/shared/src/main/scala/weaver/suites.scala
@@ -155,7 +155,7 @@ private[weaver] object TagAnalysisResult {
       extends TagAnalysisResult[A]
 }
 
-abstract class MutableFSuite[F[_]] extends SharedResourceSuite[F] {
+abstract class FSuite[F[_]] extends SharedResourceSuite[F] {
   def pureTest(name: TestName)(run: => Expectations): Unit =
     registerTest(name)(_ =>
       Test(name.name, effect.delay(run))(effect))

--- a/modules/framework-cats/jvm/src/test/scala/DogFoodTestsJVM.scala
+++ b/modules/framework-cats/jvm/src/test/scala/DogFoodTestsJVM.scala
@@ -44,7 +44,7 @@ object DogFoodTestsJVM extends IOSuite {
   // mechanism, which we test for.
   test("global sharing suites") { (dogfood, log) =>
     import dogfood._
-    runSuites(moduleSuite(Meta.MutableSuiteTest),
+    runSuites(moduleSuite(Meta.FSuiteTest),
               sharingSuite[MetaJVM.TmpFileSuite],
               globalInit(MetaJVM.GlobalStub)).flatTap(logState(log)).flatMap {
       case (logs, events) =>

--- a/modules/framework-cats/jvm/src/test/scala/MetaJVM.scala
+++ b/modules/framework-cats/jvm/src/test/scala/MetaJVM.scala
@@ -13,7 +13,7 @@ import cats.syntax.all._
 // because the framework will have ran the tests on its own.
 object MetaJVM {
 
-  object MutableSuiteTest extends MutableSuiteTest
+  object FSuiteTest extends FSuiteTest
 
   object GlobalStub extends GlobalResource {
     def sharedResources(store: GlobalWrite): Resource[IO, Unit] =

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -18,7 +18,7 @@ object DogFoodTests extends IOSuite {
 
   test("test suite reports successes events") { dogfood =>
     import dogfood._
-    runSuite(Meta.MutableSuiteTest).map {
+    runSuite(Meta.FSuiteTest).map {
       case (_, events) => forEach(events)(isSuccess)
     }
   }

--- a/modules/framework-cats/shared/src/test/scala/FSuiteTest.scala
+++ b/modules/framework-cats/shared/src/test/scala/FSuiteTest.scala
@@ -4,7 +4,7 @@ package test
 
 import scala.concurrent.duration._
 
-abstract class MutableSuiteTest extends SimpleIOSuite {
+abstract class FSuiteTest extends SimpleIOSuite {
 
   pureTest("23 is odd") {
     expect(23 % 2 == 1)
@@ -27,4 +27,4 @@ abstract class MutableSuiteTest extends SimpleIOSuite {
   }
 }
 
-object MutableSuiteTest extends MutableSuiteTest
+object FSuiteTest extends FSuiteTest

--- a/modules/framework-cats/shared/src/test/scala/Meta.scala
+++ b/modules/framework-cats/shared/src/test/scala/Meta.scala
@@ -42,7 +42,7 @@ object Meta {
     }
   }
 
-  object MutableSuiteTest extends MutableSuiteTest
+  object FSuiteTest extends FSuiteTest
 
   object Boom extends Error("Boom") with scala.util.control.NoStackTrace
 

--- a/modules/framework-cats/shared/src/test/scala/SharedResourceTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/SharedResourceTests.scala
@@ -4,7 +4,7 @@ package test
 
 import cats.effect.{ IO, Resource }
 
-object SharedResourceTests extends MutableIOSuite {
+object SharedResourceTests extends IOSuite {
   override type Res = (String, Int)
   override def sharedResource: Resource[IO, (String, Int)] =
     Resource.pure[IO, (String, Int)](("foo", 5))


### PR DESCRIPTION
The weaver `IOSuite` and `SimpleIOSuite` are type aliases to `MutableIOSuite` and `SimpleMutableIOSuite` respectively.

These aliases were introduced as part of [cats effect 3 support](https://github.com/typelevel/weaver-test/commit/e75c96b1a4cee51d21f380d0735dacde0d168947#diff-0a2f6e3372f9e542adc9002d5d713c088b2cf72dc3cb99eb7222baed35de57ff), when the codebase supported multiple effect types.

The codebase now only supports `IO` on cats effect 3, so these aliases may no longer be useful. This changeset renames the underlying `Mutable*` classes to these aliases.

## TODO
 - Add a scalafix rule renaming`MutableIOSuite` to `IOSuite`
 - [X] Remove `MutableIOSuite` from the docs.
 - [X] Remove the `Mutable` name from any internal tests.