### PR TITLE
Update Mdoc app name for doc reports.

### DIFF
--- a/modules/docs/shared/src/main/scala/main/scala/weaver/Output.scala
+++ b/modules/docs/shared/src/main/scala/main/scala/weaver/Output.scala
@@ -9,8 +9,7 @@ object Output {
   def format(s: String) = {
     Ansi2Html(removeTrailingNewLine(
       removeTrailingNewLine(
-        s.replace("repl.MdocSessionApp", "").replace("(none:",
-                                                     "(MyTests.scala:"))))
+        s.replace("repl.MdocSessionMdocApp", "").replace("(none:", "(MyTests.scala:"))))
   }
 
   def removeTrailingNewLine(s: String) = {


### PR DESCRIPTION
The Mdoc app name appears to have changed to `MdocSessionMdocApp`, and is now being displayed in test reports.

## Before
<img width="628" height="188" alt="image" src="https://github.com/user-attachments/assets/fd334335-59f4-4547-be97-18ae2747190c" />

## After
<img width="628" height="188" alt="image" src="https://github.com/user-attachments/assets/6f0654d1-f15f-4e06-93ea-93a7a40766eb" />
