### PR TITLE
Remove redundant information in failure messages

### DIFF
--- a/modules/core/shared/src/main/scala/weaver/Result.scala
+++ b/modules/core/shared/src/main/scala/weaver/Result.scala
@@ -166,17 +166,10 @@ private[weaver] object Result {
 
     val prefixIsWhitespace = prefix.trim.isEmpty
     val footer             = locationFooter(location)
-    val lines = (message.split("\\r?\\n") ++ footer).zipWithIndex.map {
-      case (line, index) =>
-        val linePrefix =
-          if (prefixIsWhitespace && line.trim.isEmpty) "" else prefix
-        if (index == 0)
-          color + linePrefix + line +
-            location
-              .map(l => s" (${formatLocationPath(l)})")
-              .mkString("\n")
-        else
-          color + linePrefix + line
+    val lines              = (message.split("\\r?\\n") ++ footer).map { line =>
+      val linePrefix =
+        if (prefixIsWhitespace && line.trim.isEmpty) "" else prefix
+      color + linePrefix + line
     }
 
     lines.mkString(EOL) + Console.RESET

--- a/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
+++ b/modules/framework-cats/jvm/src/test/scala/junit/JUnitRunnerTests.scala
@@ -60,7 +60,7 @@ object JUnitRunnerTests extends SimpleIOSuite {
           "modules/framework-cats/jvm/src/test/scala/junit/Meta.scala"
         val message =
           s"""- $name 0ms
-             |  'Only' tag is not allowed when `isCI=true` ($srcPath#L$lineNumber)
+             |  'Only' tag is not allowed when `isCI=true`
              |
              |  $srcPath#L$lineNumber
              |${sourceCode.trim.stripMargin}
@@ -169,7 +169,7 @@ object JUnitRunnerTests extends SimpleIOSuite {
                """
         val message =
           s"""- $name 0ms
-             |  'Only' tag is not allowed when `isCI=true` ($srcPath#L$lineNumber)
+             |  'Only' tag is not allowed when `isCI=true`
              |
              |  $srcPath#L$lineNumber
              |${sourceCode.trim.stripMargin}

--- a/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/DogFoodTests.scala
@@ -68,7 +68,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (failure) 0ms
-             |  expected (src/main/DogFoodTests.scala#L5)
+             |  expected
              |
              |    [INFO]  12:54:35 [DogFoodTests.scala:5] this test
              |    [ERROR] 12:54:35 [DogFoodTests.scala:5] has failed
@@ -87,9 +87,9 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (multiple-failures) 0ms
-             | [0] expected (src/main/DogFoodTests.scala#L5)
+             | [0] expected
              |
-             | [1] another (src/main/DogFoodTests.scala#L5)
+             | [1] another
              |
              |    [INFO]  12:54:35 [DogFoodTests.scala:5] this test
              |    [ERROR] 12:54:35 [DogFoodTests.scala:5] has failed
@@ -163,7 +163,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           """- (failure) 0ms
-  expected (src/main/DogFoodTests.scala#L5)
+  expected
 
     [ERROR] 12:54:35 [DogFoodTests.scala:5] error
     weaver.framework.test.Meta$CustomException: surfaced error
@@ -188,7 +188,7 @@ object DogFoodTests extends IOSuite {
              |  of
              |  multiline
              |  (failure)
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(clue(x) == y)
              |
@@ -230,7 +230,7 @@ object DogFoodTests extends IOSuite {
              |  of
              |  multiline
              |  (ignored) !!! IGNORED !!!
-             |  Ignore me (src/main/DogFoodTests.scala#L5)""".stripMargin
+             |  Ignore me""".stripMargin
         )
     }
   }
@@ -243,7 +243,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (eql Comparison) 0ms
-             |  Values not equal: (src/main/DogFoodTests.scala#L5)
+             |  Values not equal:
              |
              |  in expect.eql(- expected, + found)
              |     s: foo
@@ -262,7 +262,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (same Comparison) 0ms
-             |  Values not equal: (src/main/DogFoodTests.scala#L5)
+             |  Values not equal:
              |
              |  in expect.same(- expected, + found)
              |     s: foo
@@ -280,7 +280,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           """- (eql Show) 0ms
-  Values not equal: (src/main/DogFoodTests.scala#L5)
+  Values not equal:
 
   in expect.eql(expected, found)
   Values have the same string representation. Consider modifying their Show instance.
@@ -297,7 +297,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           """- (interpolator) 0ms
-  assertion failed (src/main/DogFoodTests.scala#L5)
+  assertion failed
 
   expect(s"$x" == "2")
 
@@ -314,13 +314,13 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (failFast) 0ms
-             | [0] Values not equal: (src/main/DogFoodTests.scala#L5)
+             | [0] Values not equal:
              | [0] 
              | [0] in expect.eql(- expected, + found)
              | [0] -1
              | [0] +2
              |
-             | [1] Values not equal: (src/main/DogFoodTests.scala#L5)
+             | [1] Values not equal:
              | [1] 
              | [1] in expect.eql(- expected, + found)
              | [1] -3
@@ -347,7 +347,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (failure) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(clue(x) == clue(y))
              |
@@ -366,7 +366,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (nested) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(clue(List(clue(x), clue(y))) == List(x, x))
              |
@@ -387,7 +387,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (map) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(List(x, y).map(v => clue(v)) == List(x, x))
              |
@@ -405,7 +405,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (all) 0ms
-             | [0] assertion failed (src/main/DogFoodTests.scala#L5)
+             | [0] assertion failed
              | [0] 
              | [0] clue(x) == clue(y)
              | [0] 
@@ -414,7 +414,7 @@ object DogFoodTests extends IOSuite {
              | [0]   y: Int = 2
              | [0] }
              |
-             | [1] assertion failed (src/main/DogFoodTests.scala#L5)
+             | [1] assertion failed
              | [1] 
              | [1] clue(y) == clue(z)
              | [1] 
@@ -433,7 +433,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (show) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(clue(x) == clue(y))
              |
@@ -452,7 +452,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (show-from-to-string) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(clue(x) == clue(y))
              |
@@ -470,7 +470,7 @@ object DogFoodTests extends IOSuite {
         assertInlineSnapshot(
           actual,
           s"""- (helpers) 0ms
-             |  assertion failed (src/main/DogFoodTests.scala#L5)
+             |  assertion failed
              |
              |  expect(CustomHelpers.clue(x) == otherclue(y) || x == clue(z))
              |
@@ -490,30 +490,30 @@ object DogFoodTests extends IOSuite {
         if (ScalaCompat.isScala3)
           assertInlineSnapshot(
             actual,
-            """- (expect-same) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L19)
-
-  in expect.same(- expected, + found)
-  -1
-  +2
-
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L19
-        expect.same(x, y)
-                        ^"""
+            s"""- (expect-same) 0ms
+               |  Values not equal:
+               |
+               |  in expect.same(- expected, + found)
+               |  -1
+               |  +2
+               |
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L19
+               |        expect.same(x, y)
+               |                        ^""".stripMargin
           )
         else
           assertInlineSnapshot(
             actual,
-            """- (expect-same) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L19)
-
-  in expect.same(- expected, + found)
-  -1
-  +2
-
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L19
-        expect.same(x, y)
-                   ^"""
+            s"""- (expect-same) 0ms
+               |  Values not equal:
+               |
+               |  in expect.same(- expected, + found)
+               |  -1
+               |  +2
+               |
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L19
+               |        expect.same(x, y)
+               |                   ^""".stripMargin
           )
     }
   }
@@ -525,50 +525,50 @@ object DogFoodTests extends IOSuite {
         if (ScalaCompat.isScala3)
           assertInlineSnapshot(
             actual,
-            """- (multiple) 0ms
- [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L26)
- [0] 
- [0] in expect.same(- expected, + found)
- [0] -1
- [0] +2
- [0] 
- [0] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
- [0]       expect.same(x, y) && expect.same(y, z)
- [0]                       ^
-
- [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L26)
- [1] 
- [1] in expect.same(- expected, + found)
- [1] -2
- [1] +3
- [1] 
- [1] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
- [1]       expect.same(x, y) && expect.same(y, z)
- [1]                                            ^"""
+            s"""- (multiple) 0ms
+               | [0] Values not equal:
+               | [0] 
+               | [0] in expect.same(- expected, + found)
+               | [0] -1
+               | [0] +2
+               | [0] 
+               | [0] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
+               | [0]       expect.same(x, y) && expect.same(y, z)
+               | [0]                       ^
+               |
+               | [1] Values not equal:
+               | [1] 
+               | [1] in expect.same(- expected, + found)
+               | [1] -2
+               | [1] +3
+               | [1] 
+               | [1] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
+               | [1]       expect.same(x, y) && expect.same(y, z)
+               | [1]                                            ^""".stripMargin
           )
         else
           assertInlineSnapshot(
             actual,
-            """- (multiple) 0ms
- [0] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L26)
- [0] 
- [0] in expect.same(- expected, + found)
- [0] -1
- [0] +2
- [0] 
- [0] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
- [0]       expect.same(x, y) && expect.same(y, z)
- [0]                  ^
-
- [1] Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L26)
- [1] 
- [1] in expect.same(- expected, + found)
- [1] -2
- [1] +3
- [1] 
- [1] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
- [1]       expect.same(x, y) && expect.same(y, z)
- [1]                                       ^"""
+            s"""- (multiple) 0ms
+               | [0] Values not equal:
+               | [0] 
+               | [0] in expect.same(- expected, + found)
+               | [0] -1
+               | [0] +2
+               | [0] 
+               | [0] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
+               | [0]       expect.same(x, y) && expect.same(y, z)
+               | [0]                  ^
+               |
+               | [1] Values not equal:
+               | [1] 
+               | [1] in expect.same(- expected, + found)
+               | [1] -2
+               | [1] +3
+               | [1] 
+               | [1] modules/framework-cats/shared/src/test/scala/Meta.scala#L26
+               | [1]       expect.same(x, y) && expect.same(y, z)
+               | [1]                                       ^""".stripMargin
           )
     }
   }
@@ -580,46 +580,42 @@ object DogFoodTests extends IOSuite {
         if (ScalaCompat.isScala3)
           assertInlineSnapshot(
             actual,
-            """- (traced) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L30)
- (modules/framework-cats/shared/src/test/scala/Meta.scala#L37)
- (modules/framework-cats/shared/src/test/scala/Meta.scala#L34)
-
-  in expect.same(- expected, + found)
-  -1
-  +2
-
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L30
-        helper
-             ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L37
-        expect.same(1, 2).traced(here)
-                                    ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L34
-        nestedHelper.traced(here)
-                               ^"""
+            s"""- (traced) 0ms
+               |  Values not equal:
+               |
+               |  in expect.same(- expected, + found)
+               |  -1
+               |  +2
+               |
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L30
+               |        helper
+               |             ^
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L37
+               |        expect.same(1, 2).traced(here)
+               |                                    ^
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L34
+               |        nestedHelper.traced(here)
+               |                               ^""".stripMargin
           )
         else
           assertInlineSnapshot(
             actual,
-            """- (traced) 0ms
-  Values not equal: (modules/framework-cats/shared/src/test/scala/Meta.scala#L30)
- (modules/framework-cats/shared/src/test/scala/Meta.scala#L37)
- (modules/framework-cats/shared/src/test/scala/Meta.scala#L34)
-
-  in expect.same(- expected, + found)
-  -1
-  +2
-
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L30
-        helper
-        ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L37
-        expect.same(1, 2).traced(here)
-                                 ^
-  modules/framework-cats/shared/src/test/scala/Meta.scala#L34
-        nestedHelper.traced(here)
-                            ^"""
+            s"""- (traced) 0ms
+               |  Values not equal:
+               |
+               |  in expect.same(- expected, + found)
+               |  -1
+               |  +2
+               |
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L30
+               |        helper
+               |        ^
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L37
+               |        expect.same(1, 2).traced(here)
+               |                                 ^
+               |  modules/framework-cats/shared/src/test/scala/Meta.scala#L34
+               |        nestedHelper.traced(here)
+               |                            ^""".stripMargin
           )
     }
   }
@@ -632,7 +628,7 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (interpolator) 0ms
-  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala#L41)
+  assertion failed
 
   expect(x == "2")
 
@@ -646,7 +642,7 @@ object DogFoodTests extends IOSuite {
           assertInlineSnapshot(
             actual,
             """- (interpolator) 0ms
-  assertion failed (modules/framework-cats/shared/src/test/scala/Meta.scala#L41)
+  assertion failed
 
   expect(x == "2")
 

--- a/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
+++ b/modules/framework-cats/shared/src/test/scala/TagDogFoodTests.scala
@@ -28,9 +28,9 @@ object TagDogFoodTests extends IOSuite {
           failureMessages,
           List(
             s"""- (should-fail) 0ms
-               |  'Only' tag is not allowed when `isCI=true` (src/main/MaoTests.scala#L1)""".stripMargin,
+               |  'Only' tag is not allowed when `isCI=true`""".stripMargin,
             s"""- (should-also-fail) 0ms
-               |  'Only' tag is not allowed when `isCI=true` (src/main/MaoTests.scala#L1)""".stripMargin
+               |  'Only' tag is not allowed when `isCI=true`""".stripMargin
           )
         )
     }

--- a/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
+++ b/modules/scalacheck/shared/src/main/scala/weaver/scalacheck/Checkers.scala
@@ -32,8 +32,12 @@ trait Checkers {
     def apply[A1: Arbitrary: Show, A2: Arbitrary: Show, B: PropF](f: (
         A1,
         A2) => B)(
-        implicit loc: SourceLocation): F[Expectations] =
+        implicit loc: SourceLocation): F[Expectations] = {
+      implicit val tuple2Show: Show[(A1, A2)] = {
+        case (a1, a2) => s"${a1.show}\n${a2.show}"
+      }
       forall_(implicitly[Arbitrary[(A1, A2)]].arbitrary, liftProp(f.tupled))
+    }
 
     def apply[
         A1: Arbitrary: Show,
@@ -43,7 +47,7 @@ trait Checkers {
         f: (A1, A2, A3) => B)(
         implicit loc: SourceLocation): F[Expectations] = {
       implicit val tuple3Show: Show[(A1, A2, A3)] = {
-        case (a1, a2, a3) => s"(${a1.show},${a2.show},${a3.show})"
+        case (a1, a2, a3) => s"${a1.show}\n${a2.show}\n${a3.show}"
       }
       forall_(implicitly[Arbitrary[(A1, A2, A3)]].arbitrary, liftProp(f.tupled))
     }
@@ -58,7 +62,7 @@ trait Checkers {
         implicit loc: SourceLocation): F[Expectations] = {
       implicit val tuple3Show: Show[(A1, A2, A3, A4)] = {
         case (a1, a2, a3, a4) =>
-          s"(${a1.show},${a2.show},${a3.show},${a4.show})"
+          s"${a1.show}\n${a2.show}\n${a3.show}\n${a4.show}"
       }
       forall_(implicitly[Arbitrary[(A1, A2, A3, A4)]].arbitrary,
               liftProp(f.tupled))
@@ -75,7 +79,7 @@ trait Checkers {
         implicit loc: SourceLocation): F[Expectations] = {
       implicit val tuple3Show: Show[(A1, A2, A3, A4, A5)] = {
         case (a1, a2, a3, a4, a5) =>
-          s"(${a1.show},${a2.show},${a3.show},${a4.show},${a5.show})"
+          s"${a1.show}\n${a2.show}\n${a3.show}\n${a4.show}\n${a5.show}"
       }
       forall_(implicitly[Arbitrary[(A1, A2, A3, A4, A5)]].arbitrary,
               liftProp(f.tupled))
@@ -93,7 +97,7 @@ trait Checkers {
         implicit loc: SourceLocation): F[Expectations] = {
       implicit val tuple3Show: Show[(A1, A2, A3, A4, A5, A6)] = {
         case (a1, a2, a3, a4, a5, a6) =>
-          s"(${a1.show},${a2.show},${a3.show},${a4.show},${a5.show},${a6.show})"
+          s"${a1.show}\n${a2.show}\n${a3.show}\n${a4.show}\n${a5.show}\n${a6.show}"
       }
       forall_(implicitly[Arbitrary[(A1, A2, A3, A4, A5, A6)]].arbitrary,
               liftProp(f.tupled))
@@ -232,7 +236,8 @@ object Checkers {
   }
 
   private def failureMessage(ith: Int, seed: Seed, input: String): String =
-    s"""Property test failed on try $ith with seed ${seed} and input $input.
+    s"""Property test failed on try $ith with input:
+       |$input
        |You can reproduce this by adding the following configuration to your test:
        |
        |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.$seed.toOption))""".stripMargin

--- a/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
+++ b/modules/scalacheck/shared/src/test/scala/weaver/scalacheck/PropertyDogFoodTest.scala
@@ -28,7 +28,8 @@ object PropertyDogFoodTest extends IOSuite {
 
       val expected =
         s"""(pure)
-           |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+           |Property test failed on try $attempt with input:
+           |$value
            |You can reproduce this by adding the following configuration to your test:
            |
            |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
@@ -48,7 +49,8 @@ object PropertyDogFoodTest extends IOSuite {
 
         val expected =
           s"""(failFast)
-             |Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+             |Property test failed on try $attempt with input:
+             |$value
              |You can reproduce this by adding the following configuration to your test:
              |
              |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))"""
@@ -69,7 +71,8 @@ object PropertyDogFoodTest extends IOSuite {
 
       val expected =
         s"""(error)
-           |PropertyTestError: Property test failed on try $attempt with seed Seed.fromBase64("$seed") and input $value.
+           |PropertyTestError: Property test failed on try $attempt with input:
+           |$value
            |You can reproduce this by adding the following configuration to your test:
            |
            |forall.withConfig(checkConfig.withInitialSeed(org.scalacheck.rng.Seed.fromBase64("$seed").toOption))


### PR DESCRIPTION
This changeset reduces the verbosity of scalacheck failures, and general failures, by removing redundant information.
 - The source location of an error is currently rendered twice: once on the first line of the error, and again when pointing to the source code. This can be noisy when the source file path is long. 
 - For scalacheck failures, the seed is rendered twice
 - For scalacheck failures, inputs are rendered on a single line. This is difficult to read when inputs have long string representations.

## Change
 - The source location on the first line has been removed from all errors
 - The scalacheck seed on the first line has been removed
 - scalacheck inputs are rendered on separate lines

## Scalacheck message before
<img width="830" height="342" alt="image" src="https://github.com/user-attachments/assets/91e84abd-8616-4030-ba19-02b696be897d" />

## Scalacheck message after
<img width="768" height="295" alt="image" src="https://github.com/user-attachments/assets/32296d82-1a00-427f-99e1-7d6b4a63458e" />


## Expectation failure before

<img width="676" height="419" alt="image" src="https://github.com/user-attachments/assets/60448619-1ab3-445c-ac3a-cc577d3d5eee" />

## Expectation failure after

<img width="550" height="360" alt="image" src="https://github.com/user-attachments/assets/11827e5f-0102-4d75-910f-d807f290b493" />


