### PR TITLE
Remove scala-reflect dependency from Scala 3 builds.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,12 +79,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         CrossVersion.for3Use2_13,
       "org.typelevel" %% "scalac-compat-annotation" %
         Version.scalacCompatAnnotation,
-      "org.scalameta" %%% "munit-diff" % Version.munitDiff,
-      if (scalaVersion.value.startsWith("3."))
-        "org.scala-lang" % "scala-reflect" % scala213
-      else
-        "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    )
+      "org.scalameta" %%% "munit-diff" % Version.munitDiff
+    ) ++
+      (if (scalaVersion.value.startsWith("3.")) Nil
+       else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value))
   )
 
 // Shades the munit-diff dependency.


### PR DESCRIPTION
`scala-reflect` is included as a dependency for Scala 3 builds, however it shouldn't be needed.

This was unearthed when compiling a project with an old version of SBT:

```scala
// SBT version 1.11.4
lazy val root = project
  .in(file("."))
  .settings(
    scalaVersion := "3.8.1",
    // Note  += instead of :=
    libraryDependencies += ("org.typelevel" %% "weaver-core" % "0.12.0" ),
  )
```

`sbt update` fails with the error:

```
[error] (update) sbt.librarymanagement.ResolveException: Error downloading org.scala-lang:scala-reflect:3.8.1
[error]   Not found
[error]   Not found
[error]   not found: ~/.ivy2/local/org.scala-lang/scala-reflect/3.8.1/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/3.8.1/scala-reflect-3.8.1.pom
```

Support for `3.8.x` was introduced in SBT `1.11.5`, removing the incorrect search for `scala-reflect`. With that said, `scala-reflect` shouldn't be needed as a dependency for Scala 3.