### PR TITLE
Use Scala Native `test-interface-sbt-defs` instead of `test-interface`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,10 +55,6 @@ val Version = new {
   val snapshot4s             = _root_.snapshot4s.BuildInfo.snapshot4sVersion
 }
 
-// Scala native test-interface version scheme is set to strict, so we have to explicitly overrule it
-ThisBuild / libraryDependencySchemes +=
-  "org.scala-native" %% "test-interface_native0.5" % "early-semver"
-
 lazy val root = tlCrossRootProject.aggregate(core,
                                              framework,
                                              coreCats,
@@ -142,7 +138,7 @@ lazy val frameworkJS = framework.js
 lazy val frameworkNative = framework.native
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-native" %%% "test-interface" % nativeVersion
+      "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion
     )
   )
 


### PR DESCRIPTION
See https://github.com/scala-native/scala-native/issues/4844

Testing libraries and frameworks should depend on Scala Native's `test-interface-sbt-defs`, not `test-interface`.
 - `test-interface-sbt-defs` defines a common interface for unit tests. It follows `early-semver` versioning.
 - `test-interface` is a server implementation that must match the version of the Scala Native plugin. It follows `strict` versioning.

This was picked up by SBT [1.12.10](https://eed3si9n.com/sbt-1.12.10), which added eviction checks for test dependencies.

## How to reproduce

Create an SBT project with the following:

```scala
// project/build.properties
sbt.version = 1.12.11
```

```scala
// project/plugins.sbt
addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
```

```scala
// build.sbt
scalaVersion := "3.3.7"
enablePlugins(ScalaNativePlugin)

ThisBuild / evictionWarningOptions := (ThisBuild / evictionWarningOptions).value
  .withConfigurations(List(Compile, Test))

libraryDependencies += "org.typelevel" %%% "weaver-cats" % "0.12.0" % Test
```

The `sbt update` command gives:

```
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-native:test-interface_native0.5_3:0.5.11 (strict) is selected over 0.5.10 for test
[error] 	    +- default:scala-native-seed-project_native0.5_3:0.1.0-SNAPSHOT (depends on 0.5.11)
[error] 	    +- org.typelevel:weaver-framework_native0.5_3:0.12.0  (depends on 0.5.10)
```
