### PR TITLE
Add scalafix rules for `0.13.0` release

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -28,7 +28,13 @@ lazy val `weaver-test` = (project in file("."))
       v0_8_3_tests.projectRefs ++
       v0_9_0_input.projectRefs ++
       v0_9_0_output.projectRefs ++
-      v0_9_0_tests.projectRefs: _*
+      v0_9_0_tests.projectRefs ++
+      v0_11_0_input.projectRefs ++
+      v0_11_0_output.projectRefs ++
+      v0_11_0_tests.projectRefs ++
+      v0_13_0_input.projectRefs ++
+      v0_13_0_output.projectRefs ++
+      v0_13_0_tests.projectRefs: _*
   )
   .settings(
     publish / skip := true
@@ -59,12 +65,21 @@ lazy val v0_11_0_input =
   makeInput("v0_11_0", "org.typelevel" %% "weaver-cats" % "0.10.1")
 lazy val v0_11_0_output =
   makeOutput("v0_11_0",
-             "org.typelevel" %% "weaver-cats" % "0.11-799b8e6-SNAPSHOT")
+             "org.typelevel" %% "weaver-cats" % "0.11.0")
 lazy val v0_11_0_tests = makeTests("v0_11_0", v0_11_0_input, v0_11_0_output)
+
+lazy val v0_13_0_input =
+  makeInput("v0_13_0", "org.typelevel" %% "weaver-cats" % "0.12.0")
+lazy val v0_13_0_output =
+  makeOutput("v0_13_0",
+             "org.typelevel" %% "weaver-cats" % "0.13-ff3228c-SNAPSHOT")
+
+lazy val v0_13_0_tests = makeTests("v0_13_0", v0_13_0_input, v0_13_0_output)
 
 lazy val testsAggregate = Project("tests", file("target/testsAggregate"))
   .aggregate(v0_8_3_tests.projectRefs ++ v0_9_0_tests.projectRefs ++
-    v0_11_0_tests.projectRefs: _*)
+    v0_11_0_tests.projectRefs ++
+    v0_13_0_tests.projectRefs: _*)
   .settings(
     publish / skip := true
   )

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"      % "0.14.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"      % "0.14.6")
 addSbtPlugin("com.eed3si9n"  % "sbt-projectmatrix" % "0.11.0")

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -2,3 +2,4 @@ fix.RenameAssertToExpect
 fix.RewriteExpect
 fix.AddClueToExpect
 fix.v0_11_0
+fix.v0_13_0

--- a/scalafix/rules/src/main/scala/fix/v0_13_0.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_13_0.scala
@@ -1,0 +1,47 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+class v0_13_0 extends SemanticRule("v0_13_0") {
+
+  override def fix(implicit doc: SemanticDocument): Patch =
+    renameMutableSuites + renameSuiteName
+
+  def renameMutableSuites(implicit doc: SemanticDocument): Patch = {
+    val suiteNames = Map(
+      "MutableIOSuite"       -> "IOSuite",
+      "MutableFSuite"        -> "FSuite",
+      "SimpleMutableIOSuite" -> "SimpleIOSuite",
+      "FunSuiteIO"           -> "FunSuite"
+    )
+    suiteNames.map { case (prevSuiteName, nextSuiteName) =>
+      val suiteSymbol = SymbolMatcher.normalized(s"weaver/$prevSuiteName")
+      doc.tree.collect {
+        case suiteSymbol(tree) =>
+          tree match {
+            case Type.Name(`prevSuiteName`) =>
+              Patch.replaceTree(tree, nextSuiteName)
+            case Importee.Name(_) =>
+              Patch.replaceTree(tree, nextSuiteName)
+            case Importee.Rename(fromTree, _) =>
+              Patch.replaceTree(fromTree, nextSuiteName)
+            case _ =>
+              Patch.empty
+          }
+      }.asPatch
+    }.asPatch
+  }
+
+  def renameSuiteName(implicit doc: SemanticDocument): Patch = {
+    val symbol = SymbolMatcher.normalized(s"weaver/EffectSuite#name().")
+    doc.tree.collect {
+      case symbol(tree) =>
+        tree match {
+          case Term.Name("name") =>
+            Patch.replaceTree(tree, "suiteName")
+          case _ => Patch.empty
+        }
+    }.asPatch
+  }
+}

--- a/scalafix/v0_13_0/input/src/main/scala/fix/RenameFunSuiteIOTest.scala
+++ b/scalafix/v0_13_0/input/src/main/scala/fix/RenameFunSuiteIOTest.scala
@@ -1,0 +1,15 @@
+/*
+rule = v0_13_0
+ */
+package fix
+
+import weaver.FunSuiteIO
+import cats.effect._
+
+object BasicFunSuiteIO extends FunSuiteIO {
+  def basicFunction(suite: FunSuiteIO): FunSuiteIO = suite
+}
+
+import weaver.{ FunSuiteIO => FunSuiteIOAlias }
+
+object AnotherFunSuiteIO extends FunSuiteIOAlias

--- a/scalafix/v0_13_0/input/src/main/scala/fix/RenameMutableIOSuiteTest.scala
+++ b/scalafix/v0_13_0/input/src/main/scala/fix/RenameMutableIOSuiteTest.scala
@@ -1,0 +1,26 @@
+/*
+rule = v0_13_0
+ */
+package fix
+
+import weaver.MutableIOSuite
+import cats.effect._
+
+object BasicMutableIOSuite extends MutableIOSuite {
+
+  type Res = Unit
+  def sharedResource: Resource[IO, Res] = Resource.unit
+
+  def basicFunction(suite: MutableIOSuite): MutableIOSuite = suite
+}
+
+import weaver.{ MutableIOSuite => MutableIOSuiteAlias }
+
+object AnotherMutableIOSuite extends MutableIOSuiteAlias {
+  type Res = Unit
+  def sharedResource: Resource[IO, Res] = Resource.unit
+}
+
+import weaver.MutableFSuite
+
+trait BasicMutableFSuite extends MutableFSuite[IO]

--- a/scalafix/v0_13_0/input/src/main/scala/fix/RenameNameToSuiteNameTest.scala
+++ b/scalafix/v0_13_0/input/src/main/scala/fix/RenameNameToSuiteNameTest.scala
@@ -1,0 +1,21 @@
+/*
+rule = v0_13_0
+ */
+package fix
+import weaver._
+
+object RenameNameToSuiteName extends SimpleIOSuite {
+
+  pureTest("basic") {
+    expect.same(name, "basic")
+  }
+
+  pureTest("other name") {
+    val name = "basic"
+    expect.same(name, "basic")
+  }
+
+  def getName(suite: SimpleIOSuite): String = {
+    suite.name
+  }
+}

--- a/scalafix/v0_13_0/input/src/main/scala/fix/RenameSimpleMutableIOSuiteTest.scala
+++ b/scalafix/v0_13_0/input/src/main/scala/fix/RenameSimpleMutableIOSuiteTest.scala
@@ -1,0 +1,15 @@
+/*
+rule = v0_13_0
+ */
+package fix
+
+import weaver.SimpleMutableIOSuite
+import cats.effect._
+
+object BasicSimpleMutableIOSuite extends SimpleMutableIOSuite {
+  def basicFunction(suite: SimpleMutableIOSuite): SimpleMutableIOSuite = suite
+}
+
+import weaver.{ SimpleMutableIOSuite => SimpleMutableIOSuiteAlias }
+
+object AnotherSimpleMutableIOSuite extends SimpleMutableIOSuiteAlias

--- a/scalafix/v0_13_0/output/src/main/scala/fix/RenameFunSuiteIOTest.scala
+++ b/scalafix/v0_13_0/output/src/main/scala/fix/RenameFunSuiteIOTest.scala
@@ -1,0 +1,12 @@
+package fix
+
+import weaver.FunSuite
+import cats.effect._
+
+object BasicFunSuiteIO extends FunSuite {
+  def basicFunction(suite: FunSuite): FunSuite = suite
+}
+
+import weaver.{ FunSuite => FunSuiteIOAlias }
+
+object AnotherFunSuiteIO extends FunSuiteIOAlias

--- a/scalafix/v0_13_0/output/src/main/scala/fix/RenameMutableIOSuiteTest.scala
+++ b/scalafix/v0_13_0/output/src/main/scala/fix/RenameMutableIOSuiteTest.scala
@@ -1,0 +1,23 @@
+package fix
+
+import weaver.IOSuite
+import cats.effect._
+
+object BasicMutableIOSuite extends IOSuite {
+
+  type Res = Unit
+  def sharedResource: Resource[IO, Res] = Resource.unit
+
+  def basicFunction(suite: IOSuite): IOSuite = suite
+}
+
+import weaver.{ IOSuite => MutableIOSuiteAlias }
+
+object AnotherMutableIOSuite extends MutableIOSuiteAlias {
+  type Res = Unit
+  def sharedResource: Resource[IO, Res] = Resource.unit
+}
+
+import weaver.FSuite
+
+trait BasicMutableFSuite extends FSuite[IO]

--- a/scalafix/v0_13_0/output/src/main/scala/fix/RenameNameToSuiteNameTest.scala
+++ b/scalafix/v0_13_0/output/src/main/scala/fix/RenameNameToSuiteNameTest.scala
@@ -1,0 +1,18 @@
+package fix
+import weaver._
+
+object RenameNameToSuiteName extends SimpleIOSuite {
+
+  pureTest("basic") {
+    expect.same(suiteName, "basic")
+  }
+
+  pureTest("other name") {
+    val name = "basic"
+    expect.same(name, "basic")
+  }
+
+  def getName(suite: SimpleIOSuite): String = {
+    suite.suiteName
+  }
+}

--- a/scalafix/v0_13_0/output/src/main/scala/fix/RenameSimpleMutableIOSuiteTest.scala
+++ b/scalafix/v0_13_0/output/src/main/scala/fix/RenameSimpleMutableIOSuiteTest.scala
@@ -1,0 +1,12 @@
+package fix
+
+import weaver.SimpleIOSuite
+import cats.effect._
+
+object BasicSimpleMutableIOSuite extends SimpleIOSuite {
+  def basicFunction(suite: SimpleIOSuite): SimpleIOSuite = suite
+}
+
+import weaver.{ SimpleIOSuite => SimpleMutableIOSuiteAlias }
+
+object AnotherSimpleMutableIOSuite extends SimpleMutableIOSuiteAlias

--- a/scalafix/v0_13_0/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/v0_13_0/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,8 @@
+package fix
+
+import scalafix.testkit._
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
+  runAllTests()
+}


### PR DESCRIPTION
The `0.13.0` rule addresses the renames in #318  and #317.

This can be added to scala-steward via [this config change](https://github.com/scala-steward-org/scala-steward/compare/main...zainab-ali:scala-steward:weaver-test_0_13_0).

Note that the `0.11.x` and `0.9.x` rule tests fail due to incorrectly applied formatting. scalafmt upgrades don't seem to respect our [excludePaths](https://github.com/typelevel/weaver-test/blob/main/.scalafmt.conf#L42). This can be addressed in #331 .