### PR TITLE
Fix `scalafmt` scalafix directory exclusion rule.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -40,6 +40,6 @@ fileOverride {
   }
 }
 project.excludePaths = [
-  "glob:scalafix/**/input/**",
-  "glob:scalafix/**/output/**"
+  "glob:**/scalafix/**/input/**",
+  "glob:**/scalafix/**/output/**"
 ]

--- a/scalafix/v0_11_0/input/src/main/scala/fix/RenameAssertionExceptionToExpectationFailedTest.scala
+++ b/scalafix/v0_11_0/input/src/main/scala/fix/RenameAssertionExceptionToExpectationFailedTest.scala
@@ -9,23 +9,19 @@ import cats.effect.IO
 object RenameAssertionExceptionToExpectationFailed extends SimpleIOSuite {
 
   test("raise") {
-    IO.raiseError(AssertionException(
-      "some reason",
-      NonEmptyList.of(implicitly[SourceLocation]))).as(success)
+    IO.raiseError(AssertionException("some reason", NonEmptyList.of(implicitly[SourceLocation]))).as(success)
   }
 
   test("match") {
     val program: IO[Unit] = IO.unit
     program.attemptTap {
       case Left(ex: AssertionException) => IO.println(ex)
-      case _                            => IO.unit
+      case _ => IO.unit
     }.as(success)
   }
 
   test("import") {
     import weaver.AssertionException
-    IO.raiseError(AssertionException(
-      "some reason",
-      NonEmptyList.of(implicitly[SourceLocation]))).as(success)
+    IO.raiseError(AssertionException("some reason", NonEmptyList.of(implicitly[SourceLocation]))).as(success)
   }
 }

--- a/scalafix/v0_11_0/output/src/main/scala/fix/RenameAssertionExceptionToExpectationFailedTest.scala
+++ b/scalafix/v0_11_0/output/src/main/scala/fix/RenameAssertionExceptionToExpectationFailedTest.scala
@@ -6,23 +6,19 @@ import cats.effect.IO
 object RenameAssertionExceptionToExpectationFailed extends SimpleIOSuite {
 
   test("raise") {
-    IO.raiseError(new ExpectationFailed(
-      "some reason",
-      NonEmptyList.of(implicitly[SourceLocation]))).as(success)
+    IO.raiseError(new ExpectationFailed("some reason", NonEmptyList.of(implicitly[SourceLocation]))).as(success)
   }
 
   test("match") {
     val program: IO[Unit] = IO.unit
     program.attemptTap {
       case Left(ex: ExpectationFailed) => IO.println(ex)
-      case _                           => IO.unit
+      case _ => IO.unit
     }.as(success)
   }
 
   test("import") {
     import weaver.ExpectationFailed
-    IO.raiseError(new ExpectationFailed(
-      "some reason",
-      NonEmptyList.of(implicitly[SourceLocation]))).as(success)
+    IO.raiseError(new ExpectationFailed("some reason", NonEmptyList.of(implicitly[SourceLocation]))).as(success)
   }
 }

--- a/scalafix/v0_9_0/input/src/main/scala/fix/AddClueToExpectTest.scala
+++ b/scalafix/v0_9_0/input/src/main/scala/fix/AddClueToExpectTest.scala
@@ -44,7 +44,7 @@ object AddClueToExpectTest extends SimpleIOSuite {
     expect(!a.isInstanceOf[Int])
   }
 
-  pureTest("select") {
+  pureTest("select"){
     val either = Left[Int, Int](1)
     expect(either.toOption.isEmpty)
   }
@@ -79,7 +79,7 @@ object AddClueToExpectTest extends SimpleIOSuite {
   }
 
   pureTest("ignore blocks") {
-    expect(Some(1).fold(true)({ _ => b == c }))
+    expect(Some(1).fold(true)({_ => b == c }))
   }
 
 }

--- a/scalafix/v0_9_0/input/src/main/scala/fix/RewriteExpectTest.scala
+++ b/scalafix/v0_9_0/input/src/main/scala/fix/RewriteExpectTest.scala
@@ -97,7 +97,7 @@ object RewriteExpectTest extends SimpleIOSuite {
   pureTest("infer order with sealed traits") {
     sealed trait Pet
     object Pet {
-      case object Cat             extends Pet
+      case object Cat extends Pet
       case class Dog(friend: Pet) extends Pet
     }
     val petCat = Pet.Cat
@@ -107,10 +107,10 @@ object RewriteExpectTest extends SimpleIOSuite {
 
   pureTest("infer order with common names") {
     val expectedId = 1
-    val actualId   = 2
+    val actualId = 2
     val obtainedId = 3
-    val result     = 4
-    expect(result == expectedId && actualId == expectedId &&
-      obtainedId == expectedId)
+    val result = 4
+    expect(result == expectedId && actualId == expectedId && obtainedId == expectedId)
   }
 }
+

--- a/scalafix/v0_9_0/output/src/main/scala/fix/AddClueToExpectTest.scala
+++ b/scalafix/v0_9_0/output/src/main/scala/fix/AddClueToExpectTest.scala
@@ -8,8 +8,7 @@ object AddClueToExpectTest extends SimpleIOSuite {
   val c: Int = 3
 
   pureTest("multiple") {
-    expect(clue(a) == clue(b)) and
-      expect(clue(b) == clue(c)) && not(expect(clue(c) == clue(a)))
+    expect(clue(a) == clue(b)) and expect(clue(b) == clue(c)) && not(expect(clue(c) == clue(a)))
   }
 
   pureTest("infix") {
@@ -42,7 +41,7 @@ object AddClueToExpectTest extends SimpleIOSuite {
     expect(!clue(a).isInstanceOf[Int])
   }
 
-  pureTest("select") {
+  pureTest("select"){
     val either = Left[Int, Int](1)
     expect(clue(either.toOption).isEmpty)
   }
@@ -65,9 +64,7 @@ object AddClueToExpectTest extends SimpleIOSuite {
 
   pureTest("all") {
     def isGreater(a: Int, b: Int, c: Int): Boolean = a > b && b > c
-    expect.all(clue(a) == clue(b),
-               clue(Some(2)).nonEmpty,
-               isGreater(clue(a), clue(b), clue(c)))
+    expect.all(clue(a) == clue(b), clue(Some(2)).nonEmpty, isGreater(clue(a), clue(b), clue(c)))
   }
 
   pureTest("ignore clue in expect.all") {
@@ -80,8 +77,8 @@ object AddClueToExpectTest extends SimpleIOSuite {
 
   pureTest("ignore blocks") {
     expect(clue(Some(1)).fold(true) {
-      _ => b == c
-    })
+  _ => b == c
+})
   }
 
 }

--- a/scalafix/v0_9_0/output/src/main/scala/fix/RewriteExpectTest.scala
+++ b/scalafix/v0_9_0/output/src/main/scala/fix/RewriteExpectTest.scala
@@ -13,8 +13,7 @@ object RewriteExpectTest extends SimpleIOSuite {
   }
 
   pureTest("nested ==") {
-    expect.same(1, 1).and(expect.same(2, 2)) and
-      expect.same(1, 1).and(expect(2 >= 2))
+    expect.same(1, 1).and(expect.same(2, 2)) and expect.same(1, 1).and(expect(2 >= 2))
   }
 
   pureTest("===") {
@@ -38,28 +37,27 @@ object RewriteExpectTest extends SimpleIOSuite {
   }
 
   pureTest("if then else if") {
-    if (1 == 2) expect(3 > 4)
-    else if (2 == 3) expect.same(5, 5) else expect(4 > 3)
+    if (1 == 2) expect(3 > 4) else if (2 == 3) expect.same(5, 5) else expect(4 > 3)
   }
 
   pureTest("match") {
     val n: Int = 1
     n match {
-      case 2 =>
-        expect(1 > 2)
-      case 3 =>
-        success
-      case 4 =>
-        failure("Assertion failed")
-    }
+  case 2 =>
+    expect(1 > 2)
+  case 3 =>
+    success
+  case 4 =>
+    failure("Assertion failed")
+}
   }
 
   pureTest("match with wildcard false") {
     val n: Int = 1
     matches(n) {
-      case 2 =>
-        expect(1 > 2)
-    }
+  case 2 =>
+    expect(1 > 2)
+}
   }
 
   pureTest("expect.all ==") {
@@ -79,8 +77,7 @@ object RewriteExpectTest extends SimpleIOSuite {
   }
 
   pureTest("expect.all with || and &&") {
-    expect(1 > 0).and(expect.same(2, 2)).and(expect(2 > 0).or(expect(3 >
-      4))).and(expect.same(2, 2))
+    expect(1 > 0).and(expect.same(2, 2)).and(expect(2 > 0).or(expect(3 > 4))).and(expect.same(2, 2))
   }
 
   pureTest("expect.all ignore clue") {
@@ -100,7 +97,7 @@ object RewriteExpectTest extends SimpleIOSuite {
   pureTest("infer order with sealed traits") {
     sealed trait Pet
     object Pet {
-      case object Cat             extends Pet
+      case object Cat extends Pet
       case class Dog(friend: Pet) extends Pet
     }
     val petCat = Pet.Cat
@@ -110,10 +107,9 @@ object RewriteExpectTest extends SimpleIOSuite {
 
   pureTest("infer order with common names") {
     val expectedId = 1
-    val actualId   = 2
+    val actualId = 2
     val obtainedId = 3
-    val result     = 4
-    expect.same(expectedId, result).and(expect.same(expectedId, actualId)).and(
-      expect.same(expectedId, obtainedId))
+    val result = 4
+    expect.same(expectedId, result).and(expect.same(expectedId, actualId)).and(expect.same(expectedId, obtainedId))
   }
 }


### PR DESCRIPTION
The `scalafix` `input` and `output` directories are not excluded properly from `scalafmt`. This was due to a mistake in the glob patterns.

As a result, scala-steward upgrades of `scalafmt` would reformat the input and output directories and break the rule tests. Rule tests are only run manually, so we didn't detect this until now.