### PR TITLE
Add GitLab source URL format to documentation.

### DIFF
--- a/docs/features/troubleshooting_failures.md
+++ b/docs/features/troubleshooting_failures.md
@@ -217,6 +217,14 @@ You can display urls in other CI providers using the `WEAVER_SOURCE_URL` environ
 export WEAVER_SOURCE_URL=https://gitlab.com/my-org/my-repo/-/tree/my-branch/
 ```
 
+Here are some common provider formats:
+
+| Provider | `WEAVER_SOURCE_URL` value                                                        |
+|----------|----------------------------------------------------------------------------------|
+| GitHub   | `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}/` (set by default) |
+| GitLab   | `${CI_PROJECT_URL}/-/tree/${CI_COMMIT_SHA}/`                                     |
+
+
 ## Displaying a trace
 
 If you have a test codebase with many nested helper functions, you may want to display a trace of source locations. You can do this with the `traced(here)` function.


### PR DESCRIPTION
GitLab has predefined `CI_PROJECT_URL` and `CI_COMMIT_SHA` environment variables. We can reference these for building source URLs.

<img width="837" height="271" alt="image" src="https://github.com/user-attachments/assets/5670a246-a64d-4015-b152-95845ac098d1" />
