### PR TITLE
Limit image width of expect macro screenshot.

### DIFF
--- a/docs/features/expectations.md
+++ b/docs/features/expectations.md
@@ -9,7 +9,7 @@ The easiest way to construct expectactions is to call the `expect` macro. The `c
 expect(clue(List(1, 2, 3).size) == 4)
 ```
 
-![Oops](../assets/oops.png)
+<img src="../assets/oops.png" alt="Error message produced by the expect macro" style="max-width: 100%; height: auto;" />
 
 
 ## TL;DR


### PR DESCRIPTION
The screenshot in the [expectations docs](https://typelevel.org/weaver-test/features/expectations.html) renders wider than the page.

# Before

<img width="883" height="514" alt="Screenshot 2026-07-29 at 12 37 32" src="https://github.com/user-attachments/assets/8f401a6b-64e4-498f-af81-6cc582e7b2a1" />

# After
<img width="821" height="409" alt="Screenshot 2026-07-29 at 12 37 21" src="https://github.com/user-attachments/assets/f27e316f-eda6-4cba-b031-1a3c2a21c965" />
